### PR TITLE
#5975 bug(refactor): removes unused classname prop from ResultItem

### DIFF
--- a/src/components/ResultItem/ResultItem.tsx
+++ b/src/components/ResultItem/ResultItem.tsx
@@ -7,7 +7,6 @@ type meta = {
 };
 
 export type ResultItemProps = {
-  className?: string;
   href: string;
   meta?: meta;
   text?: string;


### PR DESCRIPTION
Resolves https://github.com/wellcometrust/corporate/issues/5975.

- removes `className` prop from ResultItem