### PR TITLE
Feat/stylelint set order of content #6035

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -61,6 +61,16 @@
                     "selector": "&:hover|&:focus|&:active|&:visited|&:focus-within"
                 },
                 {
+                    "type": "at-rule",
+                    "name": "include",
+                    "parameter": "hocus",
+                    "hasBlock": true
+                },
+                {
+                    "type": "at-rule",
+                    "hasBlock": true
+                },
+                {
                     "type": "rule",
                     "selector": "&.is-|&.has-|[[_a-zA-Z0-9].*]$"
                 },

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -51,18 +51,18 @@
                     "hasBlock": true
                 },
                 {
+                    "type": "at-rule",
+                    "name": "include",
+                    "parameter": "mq",
+                    "hasBlock": true
+                },
+                {
                     "type": "rule",
                     "selector": "&:hover|&:focus|&:active|&:visited|&:focus-within"
                 },
                 {
                     "type": "rule",
-                    "selector": ".is-|.has-"
-                },
-                {
-                    "type": "at-rule",
-                    "name": "include",
-                    "parameter": "mq",
-                    "hasBlock": true
+                    "selector": "&.is-|&.has-|[[_a-zA-Z0-9].*]$"
                 },
                 {
                     "type": "rule",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -46,13 +46,13 @@
                 "custom-properties",
                 "declarations",
                 {
-                    "type": "rule",
-                    "selector": "&:hover|&:focus|&:active|&:visited|&:focus-within"
-                },
-                {
                     "type": "at-rule",
                     "name": "include",
                     "hasBlock": true
+                },
+                {
+                    "type": "rule",
+                    "selector": "&:hover|&:focus|&:active|&:visited|&:focus-within"
                 },
                 {
                     "type": "rule",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -18,6 +18,18 @@
             }
 
         ],
+        "at-rule-empty-line-before": [
+            "always",
+            {
+                "except": [
+                    "first-nested",
+                    "blockless-after-blockless"
+                ],
+                "ignore": [
+                    "after-comment"
+                ]
+            }
+        ],
         "scss/at-import-no-partial-leading-underscore": null,
         "scss/at-mixin-argumentless-call-parentheses": "never",
         "order/order": [
@@ -29,21 +41,32 @@
                 },
                 {
                     "type": "at-rule",
-                    "name": "extend",
-                    "hasBlock": false
+                    "name": "extend"
                 },
                 "custom-properties",
                 "declarations",
                 {
+                    "type": "rule",
+                    "selector": "&:hover|&:focus|&:active|&:visited|&:focus-within"
+                },
+                {
                     "type": "at-rule",
                     "name": "include",
                     "hasBlock": true
+                },
+                {
+                    "type": "rule",
+                    "selector": ".is-|.has-"
                 },
                 {
                     "type": "at-rule",
                     "name": "include",
                     "parameter": "mq",
                     "hasBlock": true
+                },
+                {
+                    "type": "rule",
+                    "selector": "&:before|&:after"
                 },
                 "rules"
             ]

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -22,12 +22,30 @@
         "scss/at-mixin-argumentless-call-parentheses": "never",
         "order/order": [
             [
-                "declarations",
                 {
                     "type": "at-rule",
                     "name": "include",
                     "hasBlock": false
-                }
+                },
+                {
+                    "type": "at-rule",
+                    "name": "extend",
+                    "hasBlock": false
+                },
+                "custom-properties",
+                "declarations",
+                {
+                    "type": "at-rule",
+                    "name": "include",
+                    "hasBlock": true
+                },
+                {
+                    "type": "at-rule",
+                    "name": "include",
+                    "parameter": "mq",
+                    "hasBlock": true
+                },
+                "rules"
             ]
         ],
         "selector-class-pattern": "^[a-z]([a-z0-9-]+)?(__([a-z0-9]+-?)+)?(--([a-z0-9]+-?)+){0,2}$",

--- a/src/components/Footer/styles/_20-tools.scss
+++ b/src/components/Footer/styles/_20-tools.scss
@@ -43,6 +43,11 @@
   --transition-duration: 0.3s;
   position: relative;
 
+  &:hover:before {
+    transform: scaleX(1);
+    visibility: visible;
+  }
+
   &:before {
     background-color: var(--colour-white);
     bottom: 0;
@@ -54,10 +59,5 @@
     transition: all var(--transition-duration) ease-in-out;
     visibility: hidden;
     width: 100%;
-  }
-
-  &:hover:before {
-    transform: scaleX(1);
-    visibility: visible;
   }
 }

--- a/src/components/Footer/styles/_35-footer-links.scss
+++ b/src/components/Footer/styles/_35-footer-links.scss
@@ -15,13 +15,13 @@
 }
 
 .footer-links__item {
+  @include animated-underline;
   color: var(--colour-white);
   display: inline-block;
   font-size: calc(0.875 * var(--text-base-size));
   margin: 0 var(--space-unit);
   position: relative;
   text-decoration: none;
-  @include animated-underline;
 
   &:after {
     content: '|';

--- a/src/components/Footer/styles/_35-footer-nav.scss
+++ b/src/components/Footer/styles/_35-footer-nav.scss
@@ -54,7 +54,7 @@
 }
 
 .footer-nav__menu-list-link {
+  @include animated-underline;
   @extend %footer-nav-link;
   @extend %text-xs;
-  @include animated-underline;
 }

--- a/src/components/Footer/styles/_35-footer-social.scss
+++ b/src/components/Footer/styles/_35-footer-social.scss
@@ -15,6 +15,7 @@
   @include mq(sm) {
     margin: calc(4 * var(--space-md)) 0;
   }
+
   @include mq(md) {
     margin: calc(5 * var(--space-md)) 0;
   }

--- a/src/components/Grid/styles/_20-mixins.scss
+++ b/src/components/Grid/styles/_20-mixins.scss
@@ -116,7 +116,9 @@
     grid-column: #{$col-start} / #{$col-end};
     // stylelint-disable-next-line property-no-vendor-prefix
     -ms-grid-column-span: ($col-end - $col-start) * 2 - 1;
-  } @else {
+  }
+
+  @else {
     grid-column: #{$col-start};
   }
 }
@@ -137,7 +139,9 @@
     grid-row: #{$row-start} / #{$row-end};
     // stylelint-disable-next-line property-no-vendor-prefix
     -ms-grid-row-span: ($row-end - $row-start) * 2 - 1;
-  } @else {
+  }
+
+  @else {
     grid-row: #{$row-start};
   }
 }
@@ -189,16 +193,24 @@
   @if (map-get($data, 'gap') == 'column') {
     $column-gap: true;
     $row-gap: false;
-  } @else if (map-get($data, gap) == 'row') {
+  }
+
+  @else if (map-get($data, gap) == 'row') {
     $column-gap: false;
     $row-gap: true;
-  } @else if (map-get($data, gap) == 'both') {
+  }
+
+  @else if (map-get($data, gap) == 'both') {
     $column-gap: true;
     $row-gap: true;
-  } @else if (map-get($data, gap) == 'neither') {
+  }
+
+  @else if (map-get($data, gap) == 'neither') {
     $column-gap: false;
     $row-gap: false;
-  } @else {
+  }
+
+  @else {
     @error The 'gap' argument must be one of 'column', 'row', 'both', or 'neither';
   }
 
@@ -221,9 +233,13 @@
         // This element can be filled iff we are not in a row gap or a column gap.
         @if ($i % 2 == 0 and $column-gap) {
           // This is a column gap. Don't place the next element.
-        } @else if ($j % 2 == 0 and $row-gap) {
+        }
+
+        @else if ($j % 2 == 0 and $row-gap) {
           // This is a row gap. Don't place the next element.
-        } @else {
+        }
+
+        @else {
           // Place the next element in column $i and row $j.
           // stylelint-disable-next-line max-nesting-depth
           > :nth-child(#{$counter}) {
@@ -236,15 +252,21 @@
         }
       }
     }
-  } @else if ($autoflow == 'row') {
+  }
+
+  @else if ($autoflow == 'row') {
     @for $i from 1 through $rows {
       @for $j from 1 through $columns {
         // This element can be filled iff we are not in a row gap or a column gap.
         @if ($i % 2 == 0 and $row-gap) {
           // This is a row gap. Don't place the next element.
-        } @else if ($j % 2 == 0 and $column-gap) {
+        }
+
+        @else if ($j % 2 == 0 and $column-gap) {
           // This is a column gap. Don't place the next element.
-        } @else {
+        }
+
+        @else {
           // Place the next element in row $i and column $j.
           // stylelint-disable-next-line max-nesting-depth
           > :nth-child(#{$counter}) {
@@ -277,7 +299,9 @@
         // stylelint-disable-next-line property-no-vendor-prefix
         -ms-grid-row: $i;
       }
-    } @else {
+    }
+
+    @else {
       > :nth-child(#{$counter}) {
         // stylelint-disable-next-line property-no-vendor-prefix
         -ms-grid-row: $i;

--- a/src/components/Grid/styles/_30-grid.scss
+++ b/src/components/Grid/styles/_30-grid.scss
@@ -7,14 +7,14 @@
 // ----------------------------------
 
 .grid {
-  display: grid;
-  // stylelint-disable value-no-vendor-prefix
-  display: -ms-grid;
   @include grid-container;
 
   // Columns: 6 / Gutter: 12px
   @include grid-columns($grid-gutter-xs, grid-repeat(6, 1fr));
   @include grid-rows(0, 1fr);
+  display: grid;
+  // stylelint-disable value-no-vendor-prefix
+  display: -ms-grid;
 
   @include mq(sm) {
     // Columns: 12 / Gutter: 20px
@@ -34,9 +34,9 @@
 
 // Reset nested grids
 .grid--nested {
+  @include grid-column(1, 13);
   margin-left: 0;
   margin-right: 0;
-  @include grid-column(1, 13);
 
   > * {
     @include grid-column(1, 13);

--- a/src/components/Hamburger/_hamburger.scss
+++ b/src/components/Hamburger/_hamburger.scss
@@ -4,12 +4,12 @@
   margin-left: auto;
   pointer-events: all;
 
-  &:hover {
-    color: var(--colour-white);
-  }
-
   @include mq(md) {
     display: none;
+  }
+
+  &:hover {
+    color: var(--colour-white);
   }
 
   &[disabled] {

--- a/src/components/Hamburger/_hamburger.scss
+++ b/src/components/Hamburger/_hamburger.scss
@@ -4,12 +4,12 @@
   margin-left: auto;
   pointer-events: all;
 
-  @include mq(md) {
-    display: none;
-  }
-
   &:hover {
     color: var(--colour-white);
+  }
+
+  @include mq(md) {
+    display: none;
   }
 
   &[disabled] {

--- a/src/components/Hamburger/_hamburger.scss
+++ b/src/components/Hamburger/_hamburger.scss
@@ -4,15 +4,15 @@
   margin-left: auto;
   pointer-events: all;
 
+  @include mq(md) {
+    display: none;
+  }
+
   &:hover {
     color: var(--colour-white);
   }
 
   &[disabled] {
-    display: none;
-  }
-
-  @include mq(md) {
     display: none;
   }
 }

--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -111,16 +111,16 @@
   margin-left: auto;
   text-decoration: none;
 
+  @include mq(md) {
+    display: none;
+  }
+
   .js & {
     pointer-events: none;
   }
 
   &:hover {
     text-decoration: none;
-  }
-
-  @include mq(md) {
-    display: none;
   }
 }
 
@@ -159,10 +159,6 @@
   @extend %btn-nav-base;
   color: var(--colour-grey-60);
 
-  .icon {
-    margin-right: calc(1.5 * var(--space-unit));
-  }
-
   @include mq(sm) {
     padding-left: calc(4 * var(--space-unit));
     padding-right: calc(4 * var(--space-unit));
@@ -171,19 +167,15 @@
   @include mq(md) {
     display: none;
   }
+
+  .icon {
+    margin-right: calc(1.5 * var(--space-unit));
+  }
 }
 
 .nav__btn--search-mobile {
   @extend %btn-nav-base;
   color: var(--colour-grey-60);
-
-  &:hover {
-    color: var(--colour-grey-60);
-  }
-
-  .icon {
-    margin-left: calc(1.5 * var(--space-unit));
-  }
 
   @include mq(sm) {
     padding-left: calc(4 * var(--space-unit));
@@ -197,6 +189,14 @@
     &:hover {
       color: var(--colour-white);
     }
+  }
+
+  &:hover {
+    color: var(--colour-grey-60);
+  }
+
+  .icon {
+    margin-left: calc(1.5 * var(--space-unit));
   }
 
   &.is-disabled {

--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -83,6 +83,12 @@
 }
 
 .nav__overlay {
+  &.is-active {
+    opacity: 1;
+    transition: opacity var(--transition-duration) ease, visibility 0s ease 0s;
+    visibility: visible;
+  }
+
   @include mq($until: md) {
     background: rgba(255, 255, 255, 0.6);
     bottom: 0;
@@ -95,12 +101,6 @@
     visibility: hidden;
     z-index: var(--z-medium);
   }
-
-  &.is-active {
-    opacity: 1;
-    transition: opacity var(--transition-duration) ease, visibility 0s ease 0s;
-    visibility: visible;
-  }
 }
 
 .nav__toggle {
@@ -111,16 +111,16 @@
   margin-left: auto;
   text-decoration: none;
 
+  &:hover {
+    text-decoration: none;
+  }
+
   @include mq(md) {
     display: none;
   }
 
   .js & {
     pointer-events: none;
-  }
-
-  &:hover {
-    text-decoration: none;
   }
 }
 
@@ -177,6 +177,14 @@
   @extend %btn-nav-base;
   color: var(--colour-grey-60);
 
+  &:hover {
+    color: var(--colour-grey-60);
+  }
+
+  &.is-disabled {
+    opacity: 0;
+  }
+
   @include mq(sm) {
     padding-left: calc(4 * var(--space-unit));
     padding-right: calc(4 * var(--space-unit));
@@ -191,16 +199,8 @@
     }
   }
 
-  &:hover {
-    color: var(--colour-grey-60);
-  }
-
   .icon {
     margin-left: calc(1.5 * var(--space-unit));
-  }
-
-  &.is-disabled {
-    opacity: 0;
   }
 
   &.keyboard-nav {

--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -83,12 +83,6 @@
 }
 
 .nav__overlay {
-  &.is-active {
-    opacity: 1;
-    transition: opacity var(--transition-duration) ease, visibility 0s ease 0s;
-    visibility: visible;
-  }
-
   @include mq($until: md) {
     background: rgba(255, 255, 255, 0.6);
     bottom: 0;
@@ -101,6 +95,12 @@
     visibility: hidden;
     z-index: var(--z-medium);
   }
+
+  &.is-active {
+    opacity: 1;
+    transition: opacity var(--transition-duration) ease, visibility 0s ease 0s;
+    visibility: visible;
+  }
 }
 
 .nav__toggle {
@@ -111,12 +111,12 @@
   margin-left: auto;
   text-decoration: none;
 
-  &:hover {
-    text-decoration: none;
-  }
-
   @include mq(md) {
     display: none;
+  }
+
+  &:hover {
+    text-decoration: none;
   }
 
   .js & {
@@ -177,14 +177,6 @@
   @extend %btn-nav-base;
   color: var(--colour-grey-60);
 
-  &:hover {
-    color: var(--colour-grey-60);
-  }
-
-  &.is-disabled {
-    opacity: 0;
-  }
-
   @include mq(sm) {
     padding-left: calc(4 * var(--space-unit));
     padding-right: calc(4 * var(--space-unit));
@@ -197,6 +189,14 @@
     &:hover {
       color: var(--colour-white);
     }
+  }
+
+  &:hover {
+    color: var(--colour-grey-60);
+  }
+
+  &.is-disabled {
+    opacity: 0;
   }
 
   .icon {

--- a/src/components/Nav/_nav-item.scss
+++ b/src/components/Nav/_nav-item.scss
@@ -3,6 +3,10 @@
 .nav__item {
   list-style: none;
 
+  @include mq($until: md) {
+    border-bottom: 1px solid var(--colour-grey-05);
+  }
+
   //duplication of class name for higher specificity
   &.nav__item {
     margin: 0;
@@ -12,10 +16,6 @@
 
   &.nav__item:before {
     content: none;
-  }
-
-  @include mq($until: md) {
-    border-bottom: 1px solid var(--colour-grey-05);
   }
 }
 
@@ -42,6 +42,35 @@
     calc(2.25 * var(--space-unit))
     calc(2 * var(--space-unit));
   text-decoration: none;
+
+  @include mq(sm) {
+    padding-left: calc(4 * var(--space-unit));
+    padding-right: calc(4 * var(--space-unit));
+  }
+
+  @include mq(md) {
+    color: var(--colour-white);
+    padding: calc(2 * var(--space-unit));
+
+    &:active,
+    &:focus,
+    &:hover,
+    &.active {
+      color: var(--colour-white);
+    }
+
+    .nav__link-text:before {
+      background-color: var(--colour-white);
+    }
+
+    .icon {
+      display: none;
+    }
+
+    &.active + .nav-secondary {
+      display: block;
+    }
+  }
 
   &:focus,
   &:hover {
@@ -85,35 +114,6 @@
   .nav-secondary & {
     @include mq(md) {
       align-items: stretch;
-    }
-  }
-
-  @include mq(sm) {
-    padding-left: calc(4 * var(--space-unit));
-    padding-right: calc(4 * var(--space-unit));
-  }
-
-  @include mq(md) {
-    color: var(--colour-white);
-    padding: calc(2 * var(--space-unit));
-
-    &:active,
-    &:focus,
-    &:hover,
-    &.active {
-      color: var(--colour-white);
-    }
-
-    .nav__link-text:before {
-      background-color: var(--colour-white);
-    }
-
-    .icon {
-      display: none;
-    }
-
-    &.active + .nav-secondary {
-      display: block;
     }
   }
 }

--- a/src/components/Nav/_nav-item.scss
+++ b/src/components/Nav/_nav-item.scss
@@ -43,6 +43,24 @@
     calc(2 * var(--space-unit));
   text-decoration: none;
 
+  &:focus,
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:active,
+  &:focus,
+  &:hover,
+  &.active {
+    color: var(--colour-blue-80);
+  }
+
+  &.active .nav__link-text:before,
+  &:hover .nav__link-text:before {
+    transform: scaleX(1);
+    width: 100%;
+  }
+
   @include mq(sm) {
     padding-left: calc(4 * var(--space-unit));
     padding-right: calc(4 * var(--space-unit));
@@ -72,18 +90,6 @@
     }
   }
 
-  &:focus,
-  &:hover {
-    text-decoration: none;
-  }
-
-  &:active,
-  &:focus,
-  &:hover,
-  &.active {
-    color: var(--colour-blue-80);
-  }
-
   .nav__link-text {
     align-items: center;
     display: flex;
@@ -102,12 +108,6 @@
     position: absolute;
     transform: scaleX(0);
     transition: all 0.3s ease-in-out;
-    width: 100%;
-  }
-
-  &.active .nav__link-text:before,
-  &:hover .nav__link-text:before {
-    transform: scaleX(1);
     width: 100%;
   }
 

--- a/src/components/Nav/_nav-item.scss
+++ b/src/components/Nav/_nav-item.scss
@@ -43,24 +43,6 @@
     calc(2 * var(--space-unit));
   text-decoration: none;
 
-  &:focus,
-  &:hover {
-    text-decoration: none;
-  }
-
-  &:active,
-  &:focus,
-  &:hover,
-  &.active {
-    color: var(--colour-blue-80);
-  }
-
-  &.active .nav__link-text:before,
-  &:hover .nav__link-text:before {
-    transform: scaleX(1);
-    width: 100%;
-  }
-
   @include mq(sm) {
     padding-left: calc(4 * var(--space-unit));
     padding-right: calc(4 * var(--space-unit));
@@ -88,6 +70,24 @@
     &.active + .nav-secondary {
       display: block;
     }
+  }
+
+  &:focus,
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:active,
+  &:focus,
+  &:hover,
+  &.active {
+    color: var(--colour-blue-80);
+  }
+
+  &.active .nav__link-text:before,
+  &:hover .nav__link-text:before {
+    transform: scaleX(1);
+    width: 100%;
   }
 
   .nav__link-text {
@@ -136,17 +136,17 @@
     visibility: hidden;
     z-index: var(--z-medium);
 
-    .is-active {
-      top: 0;
-      z-index: var(--z-high);
-    }
-
     &.is-active {
       transform: translate3d(0, 0, 0);
       transition:
         transform ease 0.4s,
         visibility ease 0.4s;
       visibility: visible;
+    }
+
+    .is-active {
+      top: 0;
+      z-index: var(--z-high);
     }
   }
 

--- a/src/components/SearchPane/_search-pane.scss
+++ b/src/components/SearchPane/_search-pane.scss
@@ -23,16 +23,16 @@ $transition-duration: 0.4s;
   transition: transform ease $transition-duration;
   z-index: var(--z-high);
 
-  @include mq(md) {
-    bottom: auto;
-    position: absolute;
-    transform: translate3d(0, -100%, 0);
-  }
-
   &.is-active {
     @include mq($until: md) {
       transform: translate3d(0, 0, 0);
     }
+  }
+
+  @include mq(md) {
+    bottom: auto;
+    position: absolute;
+    transform: translate3d(0, -100%, 0);
   }
 }
 
@@ -49,6 +49,10 @@ $transition-duration: 0.4s;
   width: 100%;
   z-index: var(--z-low);
 
+  &.is-active {
+    box-shadow: var(--space-xs) 0 var(--space-md) rgba(var(--colour-black), 0.1);
+  }
+
   @include mq(sm) {
     padding-left: calc(4 * var(--space-unit));
     padding-right: calc(4 * var(--space-unit));
@@ -57,10 +61,6 @@ $transition-duration: 0.4s;
   @include mq(md) {
     min-height: var(--search-height-md);
     padding: 0;
-  }
-
-  &.is-active {
-    box-shadow: var(--space-xs) 0 var(--space-md) rgba(var(--colour-black), 0.1);
   }
 }
 
@@ -183,6 +183,16 @@ $transition-duration: 0.4s;
 }
 
 .search-pane__overlay {
+  &.is-active {
+    @include mq(md) {
+      opacity: 1;
+      transition:
+        opacity $transition-duration ease,
+        visibility 0s ease 0s;
+      visibility: visible;
+    }
+  }
+
   @include mq(md) {
     background: rgba(255, 255, 255, 0.9);
     content: '';
@@ -198,15 +208,5 @@ $transition-duration: 0.4s;
     visibility: hidden;
     width: 100%;
     z-index: 0;
-  }
-
-  &.is-active {
-    @include mq(md) {
-      opacity: 1;
-      transition:
-        opacity $transition-duration ease,
-        visibility 0s ease 0s;
-      visibility: visible;
-    }
   }
 }

--- a/src/components/SearchPane/_search-pane.scss
+++ b/src/components/SearchPane/_search-pane.scss
@@ -23,16 +23,16 @@ $transition-duration: 0.4s;
   transition: transform ease $transition-duration;
   z-index: var(--z-high);
 
-  &.is-active {
-    @include mq($until: md) {
-      transform: translate3d(0, 0, 0);
-    }
-  }
-
   @include mq(md) {
     bottom: auto;
     position: absolute;
     transform: translate3d(0, -100%, 0);
+  }
+
+  &.is-active {
+    @include mq($until: md) {
+      transform: translate3d(0, 0, 0);
+    }
   }
 }
 
@@ -49,10 +49,6 @@ $transition-duration: 0.4s;
   width: 100%;
   z-index: var(--z-low);
 
-  &.is-active {
-    box-shadow: var(--space-xs) 0 var(--space-md) rgba(var(--colour-black), 0.1);
-  }
-
   @include mq(sm) {
     padding-left: calc(4 * var(--space-unit));
     padding-right: calc(4 * var(--space-unit));
@@ -61,6 +57,10 @@ $transition-duration: 0.4s;
   @include mq(md) {
     min-height: var(--search-height-md);
     padding: 0;
+  }
+
+  &.is-active {
+    box-shadow: var(--space-xs) 0 var(--space-md) rgba(var(--colour-black), 0.1);
   }
 }
 
@@ -183,16 +183,6 @@ $transition-duration: 0.4s;
 }
 
 .search-pane__overlay {
-  &.is-active {
-    @include mq(md) {
-      opacity: 1;
-      transition:
-        opacity $transition-duration ease,
-        visibility 0s ease 0s;
-      visibility: visible;
-    }
-  }
-
   @include mq(md) {
     background: rgba(255, 255, 255, 0.9);
     content: '';
@@ -208,5 +198,15 @@ $transition-duration: 0.4s;
     visibility: hidden;
     width: 100%;
     z-index: 0;
+  }
+
+  &.is-active {
+    @include mq(md) {
+      opacity: 1;
+      transition:
+        opacity $transition-duration ease,
+        visibility 0s ease 0s;
+      visibility: visible;
+    }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/wellcometrust/corporate/issues/6035

- order of content:
  - `@include` (blockless)
  - `@extend`
  - custom-properties
  - declarations
  - `@include` (with block)
  - pseudo-states
  - stateful rules (e.g. &.is-active, &.has-state)
  - `@include mq` (media queries)
  - pseudo-elements (before/after)
  - rules (nested rules)
- forces new line before at-rules
  - except first nested at-rule
  - except blockless after blockless
  - ignores at-rule after a comment