### PR TITLE
#6044 bug(style): fix search form submit button style

### DIFF
--- a/src/components/SearchForm/_search-form.scss
+++ b/src/components/SearchForm/_search-form.scss
@@ -7,13 +7,13 @@
 // ----------------------------------
 
 .search-form {
-  padding-bottom: calc(4 * var(--space-unit));
-  padding-top: calc(4 * var(--space-unit));
+  margin-bottom: calc(4 * var(--space-unit));
+  margin-top: calc(4 * var(--space-unit));
   position: relative;
 
   @include mq(md) {
-    padding-bottom: calc(8 * var(--space-unit));
-    padding-top: calc(8 * var(--space-unit));
+    margin-bottom: calc(8 * var(--space-unit));
+    margin-top: calc(8 * var(--space-unit));
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/wellcometrust/corporate/issues/6044

- uses margin-top/bottom (not padding) on `.search-form`

