### PR TITLE
fix: updated babel runtime package to fix issue with year appearing a…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,9 +2246,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-      "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.8.3",
+    "@babel/runtime": "^7.8.4",
     "classnames": "^2.2.6",
     "lodash.throttle": "^4.1.1",
     "react-cookie": "^4.0.3"

--- a/src/components/FormattedDate/FormattedDate.tsx
+++ b/src/components/FormattedDate/FormattedDate.tsx
@@ -8,7 +8,7 @@ type FormattedDateProps = {
 export const FormattedDate = ({ dateString }: FormattedDateProps) => {
   const dateObject = new Date(dateString);
 
-  return <>{isValid(dateObject) ? format(dateObject, 'd MMMM yyyy') : null}</>;
+  return <>{isValid(dateObject) ? format(dateObject, 'd MMMM y') : null}</>;
 };
 
 export default FormattedDate;


### PR DESCRIPTION
…s formatting string  and not e.g.