### PR TITLE
#6190 bug: moves runtime-corejs to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2257,7 +2257,6 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
       "integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
-      "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
@@ -7290,8 +7289,7 @@
     "core-js-pure": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.1.tgz",
-      "integrity": "sha512-yKiUdvQWq66xUc408duxUCxFHuDfz5trF5V4xnQzb8C7P/5v2gFUdyNWQoevyAeGYB1hl1X/pzGZ20R3WxZQBA==",
-      "dev": true
+      "integrity": "sha512-yKiUdvQWq66xUc408duxUCxFHuDfz5trF5V4xnQzb8C7P/5v2gFUdyNWQoevyAeGYB1hl1X/pzGZ20R3WxZQBA=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.8.4",
+    "@babel/runtime-corejs3": "^7.8.4",
     "classnames": "^2.2.6",
     "date-fns": "^2.9.0",
     "lodash.throttle": "^4.1.1"
@@ -57,7 +58,6 @@
     "@babel/preset-env": "^7.7.7",
     "@babel/preset-react": "^7.7.4",
     "@babel/preset-typescript": "^7.7.7",
-    "@babel/runtime-corejs3": "^7.8.4",
     "@storybook/addon-a11y": "^5.2.8",
     "@storybook/addon-actions": "^5.2.8",
     "@storybook/addon-knobs": "^5.2.8",


### PR DESCRIPTION
Reopens and actually solves https://github.com/wellcometrust/corporate/issues/6190 

- moves `@babel/runtime-corejs3` from devDependencies to dependencies to fix issues with that package being missing when cc is imported