### PR TITLE
Home hero - prep for responsive images

### DIFF
--- a/src/components/SlideshowHero/SlideshowHero.tsx
+++ b/src/components/SlideshowHero/SlideshowHero.tsx
@@ -10,11 +10,10 @@ type SlideshowHeroProps = {
   images?: {
     caption: string;
     credit: string;
-    focalX?: number;
-    focalY?: number;
     id: string;
-    src: string;
-    zoom?: number;
+    srcNarrow: string;
+    srcWide: string;
+    srcSuperWide: string;
   }[];
   standfirst?: string;
   animationDuration?: number;
@@ -105,7 +104,7 @@ export const SlideshowHero = ({
             {images &&
               images.map(
                 (
-                  { caption, credit, focalX = 50, focalY = 50, id, src, zoom },
+                  { caption, credit, id, srcNarrow, srcWide, srcSuperWide },
                   index
                 ) => {
                   const imageClassNames = cx('slideshow__image-container', {
@@ -120,14 +119,21 @@ export const SlideshowHero = ({
                     >
                       <div className="slideshow__image-frame-outer">
                         <div className="slideshow__image-frame">
+                          {/* TODO: 6411 - add responsive images */}
+                          {/* <picture>
+                            <?php foreach ($variables['image_data'] as $image): ?>
+                              <source
+                                type="<?php print $image['type']; ?>"
+                                media="<?php print $image['media_string']; ?>"
+                                srcset="<?php print $image['preload_url']; ?>"
+                                data-loaded-url="<?php print $image['loaded_url'] ?>">
+                            <?php endforeach; ?>
+                            <img alt="<?php print $variables['alt_text'] ?>" srcset="<?php print $variables['default_img'] ?>">
+                          </picture> */}
                           <img
-                            src={src}
+                            src={srcNarrow}
                             alt=""
                             className="slideshow__image"
-                            style={{
-                              objectPosition: `${focalX}% ${focalY}%`,
-                              transform: `scale(${zoom})`
-                            }}
                           />
                         </div>
                       </div>

--- a/src/components/SlideshowHero/SlideshowHero.tsx
+++ b/src/components/SlideshowHero/SlideshowHero.tsx
@@ -121,14 +121,23 @@ export const SlideshowHero = ({
                         <div className="slideshow__image-frame">
                           {/* TODO: 6411 - add responsive images */}
                           {/* <picture>
-                            <?php foreach ($variables['image_data'] as $image): ?>
-                              <source
-                                type="<?php print $image['type']; ?>"
-                                media="<?php print $image['media_string']; ?>"
-                                srcset="<?php print $image['preload_url']; ?>"
-                                data-loaded-url="<?php print $image['loaded_url'] ?>">
-                            <?php endforeach; ?>
-                            <img alt="<?php print $variables['alt_text'] ?>" srcset="<?php print $variables['default_img'] ?>">
+                            <source
+                              type="image/jpeg"
+                              media="(min-aspect-ratio: 16/9)"
+                              srcSet={srcSuperWide}
+                              data-loaded-url="<?php print $image['loaded_url'] ?>"
+                            />
+                            <source
+                              type="image/jpeg"
+                              media="(min-width: 768px)"
+                              srcSet={srcWide}
+                              data-loaded-url="<?php print $image['loaded_url'] ?>"
+                            />
+                            <img
+                              srcSet={srcNarrow}
+                              alt=""
+                              className="slideshow__image"
+                            />
                           </picture> */}
                           <img
                             src={srcNarrow}

--- a/src/components/SlideshowHero/SlideshowHero.tsx
+++ b/src/components/SlideshowHero/SlideshowHero.tsx
@@ -14,6 +14,7 @@ type SlideshowHeroProps = {
     focalY?: number;
     id: string;
     src: string;
+    zoom?: number;
   }[];
   standfirst?: string;
   animationDuration?: number;
@@ -103,7 +104,10 @@ export const SlideshowHero = ({
           <div className="slideshow">
             {images &&
               images.map(
-                ({ caption, credit, focalX, focalY, id, src }, index) => {
+                (
+                  { caption, credit, focalX = 50, focalY = 50, id, src, zoom },
+                  index
+                ) => {
                   const imageClassNames = cx('slideshow__image-container', {
                     [`is-active`]: index === currentSlideIndex
                   });
@@ -116,7 +120,15 @@ export const SlideshowHero = ({
                     >
                       <div className="slideshow__image-frame-outer">
                         <div className="slideshow__image-frame">
-                          <img src={src} alt="" className="slideshow__image" />
+                          <img
+                            src={src}
+                            alt=""
+                            className="slideshow__image"
+                            style={{
+                              objectPosition: `${focalX}% ${focalY}%`,
+                              transform: `scale(${zoom})`
+                            }}
+                          />
                         </div>
                       </div>
                       <figcaption className="slideshow__image-caption">

--- a/src/components/SlideshowHero/_slideshow-hero.scss
+++ b/src/components/SlideshowHero/_slideshow-hero.scss
@@ -154,7 +154,6 @@
   visibility: hidden;
 
   &.is-active {
-    display: block;
     opacity: 1;
     transition:
       opacity var(--transition-duration) ease,


### PR DESCRIPTION
- #6319 feat(deprecated): removed props for home hero image focus and zoom from frontend
- #6411 feat: prep for adding responsive images generated by backend