### PR TITLE
Feat/add parent text data attribute #5708

### DIFF
--- a/src/components/Nav/NavItem.tsx
+++ b/src/components/Nav/NavItem.tsx
@@ -9,6 +9,7 @@ type Props = {
   className?: string;
   level: number;
   parentUrl?: string;
+  parentText?: string;
   text: string;
   url: string;
   children?: React.ReactNode;
@@ -18,6 +19,7 @@ export const NavItem = ({
   className,
   level,
   parentUrl,
+  parentText,
   text,
   url,
   children
@@ -40,6 +42,8 @@ export const NavItem = ({
     }
   };
 
+  const itempath = parentText ? `${parentText}__${text}` : `${text}`;
+
   return (
     <li className={itemClasses}>
       <Link href={url} activeClassName="active">
@@ -47,6 +51,7 @@ export const NavItem = ({
           className="nav__link"
           data-level={level}
           data-parent={parentUrl}
+          data-itempath={itempath}
           href={url}
           onClick={handleItemClick}
         >

--- a/src/components/Nav/NavLinks.tsx
+++ b/src/components/Nav/NavLinks.tsx
@@ -19,6 +19,7 @@ type NavListProps = {
   data: NavDataProps;
   level?: number;
   parentUrl?: string;
+  parentText?: string;
 };
 
 type NavLinksProps = {
@@ -26,7 +27,7 @@ type NavLinksProps = {
   level?: number;
 };
 
-const NavList = ({ data, level, parentUrl }: NavListProps) => {
+const NavList = ({ data, level, parentUrl, parentText }: NavListProps) => {
   // create child nav items
   // children of the context level (e.g. level 2)
   const children = (childNodes: NavDataProps, parentNode: NavDataItemProps) =>
@@ -36,17 +37,18 @@ const NavList = ({ data, level, parentUrl }: NavListProps) => {
           key={parentNode.id}
           level={level + 1}
           text={parentNode.text}
+          parentText={parentText}
           url={parentNode.url}
           className="first"
         />
         <NavList
           data={childNodes}
+          parentText={parentNode.text}
           level={level + 1}
           parentUrl={parentNode.url}
         />
       </ul>
     );
-
   return (
     <>
       {data.map(node => (
@@ -54,6 +56,7 @@ const NavList = ({ data, level, parentUrl }: NavListProps) => {
           key={node.id}
           level={level}
           parentUrl={parentUrl}
+          parentText={parentText}
           text={node.text}
           url={node.url}
         >


### PR DESCRIPTION
Adds a data-itempath attribute to nav items to allow GTM to read this with out having to traverse the DOM to generate it