### PR TITLE
#6979 fix: Gallery Lightbox - unnecessary re-render 

### DIFF
--- a/src/components/GalleryLightBox/GalleryLightBox.tsx
+++ b/src/components/GalleryLightBox/GalleryLightBox.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useState } from 'react';
 import cx from 'classnames';
 import { useHotkeys } from 'react-hotkeys-hook';
-import shortid from 'shortid';
 
 import {
   CarouselProvider,
@@ -127,7 +126,7 @@ export const GalleryLightBox = ({
                 index={index}
                 innerClassName="cc-gallery-lightbox__slide-layout"
                 innerTag="figure"
-                key={shortid.generate()}
+                key={`gallery-lightbox-slide-${galleryId}-${index + 1}`}
               >
                 <div className="cc-gallery-lightbox__image-pane">
                   <div className="cc-gallery-lightbox__image-pane-stage">


### PR DESCRIPTION
Removal of the `shortid.generate()` function call (used as Slide component key generator) fixes an extraneous re-render of the lightbox which occured on toggling the info pane. This reloaded all lightbox images and prevented CSS transitions from showing