### PR TITLE
Feat/anchor links header offset #6435

### DIFF
--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -13,8 +13,11 @@ export const SectionTitle = ({ className, id, title }: SectionTitleProps) => {
   });
 
   return (
-    <h2 className={classNames} id={id}>
+    <h2 className={classNames}>
       {title}
+      <span id={id} className="cc-section__title-anchor">
+        &nbsp;
+      </span>
     </h2>
   );
 };

--- a/src/components/SectionTitle/_section-title.scss
+++ b/src/components/SectionTitle/_section-title.scss
@@ -10,5 +10,18 @@
   @extend %heading-base;
   @extend %heading-hero;
   @include heading-divider;
+  position: relative;
   text-align: center;
+}
+
+.cc-section__title-anchor {
+  display: block;
+  left: 0;
+  position: absolute;
+  top: calc(-1 * var(--header-height));
+  visibility: hidden;
+  
+  @include mq(sm) {
+    top: calc(-1 * var(--header-height-sm));
+  }
 }


### PR DESCRIPTION
Addresses the problem of in-page anchors being obscured by the header nav by adding a negatively offset child element adjacent to each section title. No JS needed huzzah!

🎠 🎠 🎠 🎠 🎠 🎠 🎠 
