### PR TITLE
#6711, #6712, #6788, Listing variant logic and Card component

### DIFF
--- a/src/assets/styles/50-utilities/_scaffolding.scss
+++ b/src/assets/styles/50-utilities/_scaffolding.scss
@@ -10,6 +10,10 @@
   @include grid-column(1, 7);
   width: 100%;
   
+  @include mq(sm) {    
+    @include grid-column(1, 13);
+  }
+
   @include mq(md) {
     @include grid-column(4, 10);
   }
@@ -26,7 +30,11 @@
 }
 
 .u-scaffold-grid-item--wide {
-  @include mq($from: sm, $until: md) {
+  @include mq(sm) {
+    @include grid-column(2, 12);
+  }
+
+  @include mq(md) {
     @include grid-column(1, 13);
   }
 }

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -6,9 +6,10 @@ import Card from './Card';
 import Readme from './Card.md';
 
 const CardExample = () => {
-  const cardTitleText = text('Title', 'My section');
+  const cardHrefText = text('href', 'My section');
+  const cardTitleText = text('title', 'My section');
 
-  return <Card title={cardTitleText} />;
+  return <Card href={cardHrefText} title={cardTitleText} />;
 };
 
 const stories = storiesOf('Components|Listings', module);

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import Card from './Card';
 
 describe('<Card />', () => {
-  const output = shallow(<Card title="My heading" />);
+  const output = shallow(<Card href="/test" title="My heading" />);
 
   it('renders the component', () => {
     expect(output);

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,18 +3,42 @@ import cx from 'classnames';
 
 type CardProps = {
   className?: string;
+  href: string;
   id?: string;
   title: string;
 };
 
-export const Card = ({ className, id, title }: CardProps) => {
+export const Card = ({ className, href, id, title }: CardProps) => {
   const classNames = cx('cc-card', {
     [`${className}`]: className
   });
 
   return (
-    <div>
-      <h2 className={classNames}>{title}</h2>
+    <div className={classNames}>
+      <div className="card__image">
+        <div className="promo__image-ratio">
+          <img
+            alt="People at a street flea market in Italy."
+            className="cc-card__image"
+            src="https://placehold.it/600x342"
+          />
+        </div>
+      </div>
+      <div className="card__content">
+        <p className="card__type">Opinion</p>
+        <h3 className="card__title">
+          <a href={href} className="card__link" target="_self">
+            {title}
+          </a>
+        </h3>
+        <div className="card__meta">
+          <dl className="card__authors">
+            <dt className="card__authors-label">Author</dt>
+            <dd className="card__author">Jeremy Farrar</dd>
+          </dl>
+          <time className="card__date">30 June 2020</time>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -9,3 +9,7 @@
 .cc-card {
   // 
 }
+
+.cc-card__image {
+  @extend %image-responsive;
+}

--- a/src/components/InfoBox/InfoBox.stories.tsx
+++ b/src/components/InfoBox/InfoBox.stories.tsx
@@ -40,9 +40,9 @@ const InfoBoxExample = () => {
         <Contact name="Bertie Basset" />
       </Listing>
       <Listing>
-        <ListingLink href="#1">Link 1 text</ListingLink>
-        <ListingLink href="#2">Link 2 text</ListingLink>
-        <ListingLink href="#3">Link 3 text</ListingLink>
+        <ListingLink href="#1" title="Link 1 text" />
+        <ListingLink href="#2" title="Link 2 text" />
+        <ListingLink href="#3" title="Link 3 text" />
       </Listing>
     </InfoBox>
   );

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -45,12 +45,14 @@ const isExternalLink = (url: string) => {
  * @constructor
  */
 export const Link = ({ children, className, to, ...props }: LinkProps) => {
-  const [isExternal, setExternal] = useState(null);
+  const [isExternal, setExternal] = useState(false);
   const isFile = isFileLink(to);
 
   // Ensures 'window' is present
   useEffect(() => {
-    setExternal(isExternalLink(to));
+    if (to) {
+      setExternal(isExternalLink(to));
+    }
   }, []);
 
   return isExternal || isFile ? (

--- a/src/components/Listing/Listing.tsx
+++ b/src/components/Listing/Listing.tsx
@@ -1,21 +1,21 @@
-import React from 'react';
+import React, { Children, cloneElement } from 'react';
 import cx from 'classnames';
 
-import Grid from 'Grid';
+import ListingElement from './ListingElement';
 import ListingLink from './ListingLink';
 
 type ListingProps = {
   as?: 'div' | 'ol' | 'ul';
-  children: React.ReactNode;
+  children: JSX.Element | JSX.Element[];
   className?: string;
-  variant?: 'link_list' | 'text_list' | 'horizontal_card' | 'vertical_card';
+  variant?: 'horizontal_card' | 'link_list' | 'text_list' | 'vertical_card';
 };
 
 // Specific style variations for card listings
 const variantMapping = {
   horizontal_card: 'cc-card-listing cc-card-listing--horizontal',
-  link_list: '',
-  text_list: '',
+  link_list: 'cc-listing',
+  text_list: 'cc-text-listing',
   vertical_card: 'cc-card-listing'
 };
 
@@ -23,18 +23,24 @@ export const Listing = ({
   as = 'div',
   children,
   className,
-  variant
+  variant = 'link_list'
 }: ListingProps) => {
   const Element = as;
-  const classNames = cx(
-    variantMapping[variant] ? variantMapping[variant] : 'cc-listing',
-    {
-      [`${className}`]: className
-    }
+  const classNames = cx(variantMapping[variant], {
+    [`${className}`]: className
+  });
+
+  const childrenWithProps = Children.map(children, child =>
+    cloneElement(child, {
+      /**
+       * Pass the variant type to the child elements
+       */
+      variant
+    })
   );
 
-  return <Element className={classNames}>{children}</Element>;
+  return <Element className={classNames}>{childrenWithProps}</Element>;
 };
 
 export default Listing;
-export { ListingLink };
+export { ListingElement, ListingLink };

--- a/src/components/Listing/Listing.tsx
+++ b/src/components/Listing/Listing.tsx
@@ -8,12 +8,14 @@ type ListingProps = {
   as?: 'div' | 'ol' | 'ul';
   children: React.ReactNode;
   className?: string;
-  variant?: 'horizontal_card' | 'vertical_card';
+  variant?: 'link_list' | 'text_list' | 'horizontal_card' | 'vertical_card';
 };
 
 // Specific style variations for card listings
 const variantMapping = {
   horizontal_card: 'cc-card-listing cc-card-listing--horizontal',
+  link_list: '',
+  text_list: '',
   vertical_card: 'cc-card-listing'
 };
 
@@ -31,11 +33,7 @@ export const Listing = ({
     }
   );
 
-  return (
-    <Grid>
-      <Element className={classNames}>{children}</Element>
-    </Grid>
-  );
+  return <Element className={classNames}>{children}</Element>;
 };
 
 export default Listing;

--- a/src/components/Listing/ListingElement/ListingElement.tsx
+++ b/src/components/Listing/ListingElement/ListingElement.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import cx from 'classnames';
+
+import Card from 'Card';
+import { ListingLink } from 'Listing/ListingLink/ListingLink';
+
+type ListingElementProps = {
+  className?: string;
+  href: string;
+  title: string;
+  variant: 'horizontal_card' | 'link_list' | 'text_list' | 'vertical_card';
+};
+
+const variantElement = {
+  horizontal_card: Card,
+  link_list: ListingLink,
+  // TODO #6715: add item component for Text Listing
+  text_list: Card,
+  vertical_card: Card
+};
+
+export const ListingElement = ({
+  className,
+  href,
+  title,
+  variant
+}: ListingElementProps) => {
+  const classNames = cx({
+    'cc-card--horizontal': variant === 'horizontal_card',
+    [`${className}`]: className
+  });
+
+  const Element = variantElement[variant];
+
+  // TODO #6711, #6715: pass through additional props for populating text listing items / cards
+  return <Element className={classNames} href={href} title={title} />;
+};
+
+export default ListingElement;

--- a/src/components/Listing/ListingElement/index.ts
+++ b/src/components/Listing/ListingElement/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ListingElement';

--- a/src/components/Listing/ListingLink/ListingLink.stories.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.stories.tsx
@@ -24,9 +24,7 @@ const links = [
 const LinkListExample = () => (
   <Listing as="ul">
     {links.map(({ href, text }) => (
-      <ListingLink key={`listing-item-${href}`} href={href}>
-        {text}
-      </ListingLink>
+      <ListingLink key={`listing-item-${href}`} href={href} title={text} />
     ))}
   </Listing>
 );

--- a/src/components/Listing/ListingLink/ListingLink.test.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.test.tsx
@@ -24,9 +24,7 @@ describe('<ListingLink />', () => {
   const output = shallow(
     <Listing as="ul">
       {links.map(({ href, text }) => (
-        <ListingLink key={`listing-item-${href}`} href={href}>
-          {text}
-        </ListingLink>
+        <ListingLink key={`listing-item-${href}`} href={href} title={text} />
       ))}
     </Listing>
   );

--- a/src/components/Listing/ListingLink/ListingLink.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.tsx
@@ -6,17 +6,17 @@ import Icon from 'Icon';
 import Link from 'Link';
 
 type ListingLinkProps = {
-  children: React.ReactNode;
   className?: string;
   fileMeta?: FileMetaProps;
   href: string;
+  title: string;
 };
 
 export const ListingLink = ({
-  children,
   className,
   fileMeta,
-  href
+  href,
+  title
 }: ListingLinkProps) => {
   const classNames = cx('cc-listing__item', {
     [`${className}`]: className
@@ -25,8 +25,8 @@ export const ListingLink = ({
   return (
     <li className={classNames}>
       <Link className="cc-listing__link" to={href}>
-        {children}
-        {fileMeta && (
+        {title}
+        {fileMeta?.type && fileMeta?.size && (
           <>
             {' '}
             <span className="cc-listing__link-meta">

--- a/src/components/Listing/_listing.scss
+++ b/src/components/Listing/_listing.scss
@@ -23,6 +23,15 @@
 .cc-card-listing--horizontal {
   @include mq(md) {
     @include grid-column(1, 13);
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    > * {
+      flex-grow: 0;
+      flex-shrink: 0;
+      width: 33.33%;
+    }
   }
 }
 

--- a/src/components/Listing/index.ts
+++ b/src/components/Listing/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Listing';
+export { default, ListingElement, ListingLink } from './Listing';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export { Image } from 'Image/Image';
 export { ImageBanner } from 'ImageBanner/ImageBanner';
 export { InfoBox } from 'InfoBox/InfoBox';
 export { InpageNav } from 'InpageNav/InpageNav';
-export { Listing, ListingLink } from 'Listing/Listing';
+export { Listing, ListingElement, ListingLink } from 'Listing/Listing';
 export { Logo } from 'Logo/Logo';
 export { Main } from 'Main/Main';
 export { NavItem } from 'Nav/NavItem';


### PR DESCRIPTION
#6712 feat, #6788 feat: Listing component logic (WIP)

* Added ListingElement as catch-all listing item to determine child component which is used to populate a <Listing />
* Updated Listing component to pass through the variant type to child components

#6711 feat: Card component (WIP)
