### PR TITLE
#7173 feature: adds SiteAlert component + styles

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -42,6 +42,7 @@
 @import './src/components/SearchPane/search-pane';
 @import './src/components/Section/section';
 @import './src/components/SectionTitle/section-title';
+@import './src/components/SiteAlert/site-alert';
 @import './src/components/SlideshowHero/slideshow-hero';
 @import './src/components/SocialShare/social-share';
 @import './src/components/Text/text';

--- a/src/components/SiteAlert/SiteAlert.stories.tsx
+++ b/src/components/SiteAlert/SiteAlert.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import SiteAlert from 'SiteAlert';
+
+const SiteAlertExample = () => {
+  const isActive = boolean('isActive', true);
+  const urlString = text('url', 'https://wellcome.ac.uk/');
+  const textString = text('text', 'Visit the Wellcome Trust website');
+
+  return <SiteAlert isActive={isActive} text={textString} url={urlString} />;
+};
+
+const stories = storiesOf('Components|SiteAlert', module);
+
+stories.add('SiteAlert', SiteAlertExample);

--- a/src/components/SiteAlert/SiteAlert.test.tsx
+++ b/src/components/SiteAlert/SiteAlert.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { boolean } from '@storybook/addon-knobs';
+
+import SiteAlert from './SiteAlert';
+
+describe('<SiteAlert />', () => {
+  const output = shallow(
+    <SiteAlert
+      isActive
+      text="Visit the Wellcome Trust website"
+      url="https://wellcome.ac.uk/"
+    />
+  );
+
+  it('renders the component', () => {
+    expect(output);
+  });
+});

--- a/src/components/SiteAlert/SiteAlert.tsx
+++ b/src/components/SiteAlert/SiteAlert.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import cx from 'classnames';
+
+import Icon from 'Icon/Icon';
+
+type SiteAlertProps = {
+  handleClose?: () => void;
+  isActive: boolean;
+  text: string;
+  url?: string;
+};
+
+export const SiteAlert = ({
+  handleClose,
+  isActive,
+  text,
+  url
+}: SiteAlertProps) => {
+  const classNames = cx('site-alert', {
+    'is-active': isActive
+  });
+
+  const tabIndex = isActive ? 0 : -1;
+
+  return (
+    <div className={classNames}>
+      <div className="site-alert__container">
+        {url ? (
+          <a
+            href={url}
+            className="site-alert__link no-external-marker"
+            tabIndex={tabIndex}
+          >
+            {text}
+            <Icon name="arrow" />
+          </a>
+        ) : (
+          <p className="site-alert__text">{text}</p>
+        )}
+        <button
+          className="site-alert__btn-close"
+          onClick={handleClose}
+          type="button"
+          tabIndex={tabIndex}
+        >
+          Close
+          <Icon name="closeBold" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SiteAlert;

--- a/src/components/SiteAlert/_site-alert.scss
+++ b/src/components/SiteAlert/_site-alert.scss
@@ -1,0 +1,92 @@
+:root {
+  --site-alert-height: calc(7.5 * var(--space-unit));
+  --site-alert-colour-text: #292929;
+  --site-alert-colour-yellow: #ffce3c;
+
+  @include mq(xs) {
+    --site-alert-height: calc(5 * var(--space-unit));
+  }
+}
+
+.site-alert {
+  height: 0;
+  overflow: hidden;
+  position: relative;
+  transition: height 0.4s ease;
+
+  &.is-active {
+    height: var(--site-alert-height);
+  }
+}
+
+.site-alert__container {
+  align-items: center;
+  background: var(--site-alert-colour-yellow);
+  bottom: 0;
+  display: flex;
+  font-size: var(--body-md);
+  height: var(--site-alert-height);
+  justify-content: space-between;
+  left: 0;
+  line-height: var(--heading-line-height);
+  padding: calc(0.625 * var(--space-unit)) calc(2.5 * var(--space-unit));
+  position: absolute;
+  right: 0;
+
+  @include mq(sm) {
+    &:before {
+      content: '';
+      display: block;
+      flex: 0 0 auto;
+      width: 5rem;
+    }
+  }
+}
+
+.site-alert__link {
+  align-items: center;
+  color: var(--site-alert-colour-text);
+  display: flex;
+  font-family: var(--font-secondary);
+  max-width: 66%;
+
+  .icon {
+    height: calc(1.5 * var(--space-unit));
+    margin-left: var(--space-unit);
+    width: calc(1.5 * var(--space-unit));
+
+    @include mq(xs) {
+      margin-left: calc(2 * var(--space-unit));
+    }
+  }
+}
+
+.site-alert__link.site-alert__link:active,
+.site-alert__link.site-alert__link:focus,
+.site-alert__link.site-alert__link:hover {
+  color: var(--site-alert-colour-text);
+  text-decoration: none;
+}
+
+.site-alert__text {
+  @extend %margin-0;
+}
+
+.site-alert__btn-close {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--site-alert-colour-text);
+  cursor: pointer;
+  display: flex;
+  font-size: var(--body-md);
+  padding: var(--space-unit);
+  position: relative;
+
+  .icon {
+    height: calc(1.5 * var(--space-unit));
+    margin-left: var(--space-unit);
+    width: calc(1.5 * var(--space-unit));
+  }
+}

--- a/src/components/SiteAlert/_site-alert.scss
+++ b/src/components/SiteAlert/_site-alert.scss
@@ -1,6 +1,5 @@
 :root {
   --site-alert-height: calc(7.5 * var(--space-unit));
-  --site-alert-colour-text: #292929;
   --site-alert-colour-yellow: #ffce3c;
 
   @include mq(xs) {
@@ -45,7 +44,7 @@
 
 .site-alert__link {
   align-items: center;
-  color: var(--site-alert-colour-text);
+  color: var(--colour-grey-80);
   display: flex;
   font-family: var(--font-secondary);
   max-width: 66%;
@@ -64,7 +63,7 @@
 .site-alert__link.site-alert__link:active,
 .site-alert__link.site-alert__link:focus,
 .site-alert__link.site-alert__link:hover {
-  color: var(--site-alert-colour-text);
+  color: var(--colour-grey-80);
   text-decoration: none;
 }
 
@@ -77,7 +76,7 @@
   appearance: none;
   background: transparent;
   border: 0;
-  color: var(--site-alert-colour-text);
+  color: var(--colour-grey-80);
   cursor: pointer;
   display: flex;
   font-size: var(--body-md);

--- a/src/components/SiteAlert/index.ts
+++ b/src/components/SiteAlert/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SiteAlert';

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export { SearchForm } from 'SearchForm/SearchForm';
 export { SearchPane } from 'SearchPane/SearchPane';
 export { Section } from 'Section/Section';
 export { SectionTitle } from 'SectionTitle/SectionTitle';
+export { default as SiteAlert } from 'SiteAlert';
 export { SlideshowHero } from 'SlideshowHero/SlideshowHero';
 export { SocialShare } from 'SocialShare/SocialShare';
 export { Text } from 'Text/Text';


### PR DESCRIPTION
### Context

We need to utilise what is now highly specific piece of UI (the WellcomeCollectionBanner) for another purpose, so we may as well create a much more agnostic component (a SiteAlert) which can be used for a multitude of purposes in the same context. This PR creates that component.

See https://github.com/wellcometrust/corporate/issues/7173 for more.

- adds SiteAlert component (in prep for moving WellcomeCollectionBanner)
- adds styles
- adds test file
- adds storybook file