### PR TITLE
#7181 feature: aligns CookieMessage, SiteAlert & WellcomeCollectionBanner prop names

### DIFF
--- a/src/components/CookieMessage/CookieMessage.tsx
+++ b/src/components/CookieMessage/CookieMessage.tsx
@@ -4,12 +4,12 @@ import Button from 'Button';
 import Icon from 'Icon';
 
 type CookieMessageProps = {
-  handleItemClick?: () => void;
+  handleDismiss?: () => void;
   isActive: boolean;
 };
 
 export const CookieMessage = ({
-  handleItemClick,
+  handleDismiss,
   isActive
 }: CookieMessageProps) => {
   return isActive ? (
@@ -43,7 +43,7 @@ export const CookieMessage = ({
         <Button
           className="cookie-message__button"
           href="#main"
-          onClick={handleItemClick}
+          onClick={handleDismiss}
         >
           Accept and close
         </Button>

--- a/src/components/SiteAlert/SiteAlert.tsx
+++ b/src/components/SiteAlert/SiteAlert.tsx
@@ -4,14 +4,14 @@ import cx from 'classnames';
 import Icon from 'Icon/Icon';
 
 type SiteAlertProps = {
-  handleClose?: () => void;
+  handleDismiss?: () => void;
   isActive: boolean;
   text: string;
   url?: string;
 };
 
 export const SiteAlert = ({
-  handleClose,
+  handleDismiss,
   isActive,
   text,
   url
@@ -39,7 +39,7 @@ export const SiteAlert = ({
         )}
         <button
           className="site-alert__btn-close"
-          onClick={handleClose}
+          onClick={handleDismiss}
           type="button"
           tabIndex={tabIndex}
         >

--- a/src/components/WellcomeCollectionBanner/WellcomeCollectionBanner.tsx
+++ b/src/components/WellcomeCollectionBanner/WellcomeCollectionBanner.tsx
@@ -4,12 +4,12 @@ import cx from 'classnames';
 import Icon from 'Icon/Icon';
 
 type WellcomeCollectionBannerProps = {
-  handleItemClick?: () => void;
+  handleDismiss?: () => void;
   isActive: boolean;
 };
 
 export const WellcomeCollectionBanner = ({
-  handleItemClick,
+  handleDismiss,
   isActive
 }: WellcomeCollectionBannerProps) => {
   const bannerClassName = cx('wc-banner', {
@@ -32,7 +32,7 @@ export const WellcomeCollectionBanner = ({
 
         <button
           className="wc-banner__btn-close"
-          onClick={handleItemClick}
+          onClick={handleDismiss}
           type="button"
           tabIndex={bannerTabIndex}
         >


### PR DESCRIPTION
### Context 

The CookieMessage, SiteAlert & WellcomeCollectionBanner components are used in the same way from corporate-react - we pass a callback to handle dismissing the alert. However the three have different prop names for that handler, so we are aligning them to simplify the implementation in corporate-react.

See https://github.com/wellcometrust/corporate/issues/7181 for more.

- updates CookieMessage to use handleDismiss rather than handleItemClick
- updates SiteAlert to use handleDismiss rather than handleClose
- updates WellcomeCollectionBanner to use handleDismiss rather than handleItemClick
