### PR TITLE
#7215 bug: updates height attribute of SiteAlert

### DIFF
--- a/src/components/SiteAlert/_site-alert.scss
+++ b/src/components/SiteAlert/_site-alert.scss
@@ -1,8 +1,12 @@
 :root {
-  --site-alert-height: calc(7.5 * var(--space-unit));
+  --site-alert-height: calc(9 * var(--space-unit));
   --site-alert-colour-yellow: #ffce3c;
 
   @include mq(xs) {
+    --site-alert-height: calc(6.5 * var(--space-unit));
+  }
+
+  @include mq(sm) {
     --site-alert-height: calc(5 * var(--space-unit));
   }
 }


### PR DESCRIPTION
Relates to https://github.com/wellcometrust/corporate/issues/7215

- increases height of `.site-alert` to allow for updated DotOrgBanner (longer) text