### PR TITLE
#7239 feature: adds FormFieldHint component + export

### DIFF
--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 
 type DateInputProps = {
   className?: string;
+  describedBy?: string;
   id: string;
   isInvalid?: boolean;
   isRequired?: boolean;
@@ -11,7 +12,7 @@ type DateInputProps = {
 
 export const DateInput = forwardRef(
   (
-    { className, id, isInvalid, isRequired, name }: DateInputProps,
+    { className, describedBy, id, isInvalid, isRequired, name }: DateInputProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
     const classNames = cx('cc-date-input', {
@@ -21,6 +22,7 @@ export const DateInput = forwardRef(
 
     return (
       <input
+        aria-describedby={describedBy}
         className={classNames}
         id={id}
         name={name}

--- a/src/components/FormFieldHint/FormFieldHint.tsx
+++ b/src/components/FormFieldHint/FormFieldHint.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import cx from 'classnames';
+
+type FormFieldHintProps = {
+  children: JSX.Element[] | JSX.Element;
+  className?: string;
+  id: string;
+};
+
+export const FormFieldHint = ({
+  children,
+  className,
+  id
+}: FormFieldHintProps) => {
+  const classNames = cx('cc-form-field-hint', {
+    [className]: className
+  });
+
+  return (
+    <div className={classNames} id={id}>
+      {children}
+    </div>
+  );
+};
+
+export default FormFieldHint;

--- a/src/components/FormFieldHint/index.ts
+++ b/src/components/FormFieldHint/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FormFieldHint';

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 
 type RadioInputProps = {
   className?: string;
+  describedBy?: string;
   id: string;
   isInvalid?: boolean;
   isRequired?: boolean;
@@ -12,7 +13,15 @@ type RadioInputProps = {
 
 export const RadioInput = forwardRef(
   (
-    { className, id, isInvalid, isRequired, name, value }: RadioInputProps,
+    {
+      className,
+      describedBy,
+      id,
+      isInvalid,
+      isRequired,
+      name,
+      value
+    }: RadioInputProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
     const classNames = cx('cc-radio-input', {
@@ -22,6 +31,7 @@ export const RadioInput = forwardRef(
 
     return (
       <input
+        aria-describedby={describedBy}
         className={classNames}
         id={id}
         name={name}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 
 type TextInputProps = {
   className?: string;
+  describedBy?: string;
   id: string;
   isInvalid?: boolean;
   isRequired?: boolean;
@@ -11,7 +12,7 @@ type TextInputProps = {
 
 export const TextInput = forwardRef(
   (
-    { className, id, isInvalid, isRequired, name }: TextInputProps,
+    { className, describedBy, id, isInvalid, isRequired, name }: TextInputProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
     const classNames = cx('cc-text-input', {
@@ -21,6 +22,7 @@ export const TextInput = forwardRef(
 
     return (
       <input
+        aria-describedby={describedBy}
         className={classNames}
         id={id}
         name={name}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { default as DateInput } from 'DateInput';
 export { Footer } from 'Footer/Footer';
 export { FormattedDate } from 'FormattedDate/FormattedDate';
 export { default as FormField } from 'FormField';
+export { default as FormFieldHint } from 'FormFieldHint';
 export { FileDownload } from 'FileDownload/FileDownload';
 export { Gallery, GalleryMedia } from 'Gallery/Gallery';
 export { Grid, GridCell } from 'Grid/Grid';


### PR DESCRIPTION
Relates to https://github.com/wellcometrust/corporate/issues/7239

- creates FormFieldHint component + exports
- adds describedBy prop to TextInput, RadioInput, DateInput https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute