### PR TITLE
#7241 feature: adds label prop to RadioInput

### DIFF
--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -46,7 +46,7 @@ export const RadioInput = forwardRef(
       </div>
     ) : (
       <input
-        className={cx({ [className]: className })}
+        className={className ? cx({ [className]: className }) : undefined}
         id={id}
         name={name}
         ref={ref}

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -1,18 +1,29 @@
 import React, { forwardRef } from 'react';
 import cx from 'classnames';
 
+import Label from 'Label';
+
 type RadioInputProps = {
   className?: string;
   id: string;
   isInvalid?: boolean;
   isRequired?: boolean;
+  label?: string;
   name: string;
   value: string;
 };
 
 export const RadioInput = forwardRef(
   (
-    { className, id, isInvalid, isRequired, name, value }: RadioInputProps,
+    {
+      className,
+      id,
+      isInvalid,
+      isRequired,
+      label,
+      name,
+      value
+    }: RadioInputProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
     const classNames = cx('cc-radio-input', {
@@ -20,9 +31,22 @@ export const RadioInput = forwardRef(
       [className]: className
     });
 
-    return (
+    return label ? (
+      <div className={classNames}>
+        <Label text={label} htmlFor={id} className="cc-radio-input__label" />
+        <input
+          className="cc-radio-input__toggle"
+          id={id}
+          name={name}
+          ref={ref}
+          required={isRequired}
+          type="radio"
+          value={value}
+        />
+      </div>
+    ) : (
       <input
-        className={classNames}
+        className={cx({ [className]: className })}
         id={id}
         name={name}
         ref={ref}

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -46,7 +46,7 @@ export const RadioInput = forwardRef(
       </div>
     ) : (
       <input
-        className={className ? cx({ [className]: className }) : undefined}
+        className={className ? cx({ [className]: className }) : null}
         id={id}
         name={name}
         ref={ref}


### PR DESCRIPTION
Relates to https://github.com/wellcometrust/corporate/issues/7241

- adds `label` prop to RadioInput
- refactors RadioInput to allow conditional rendering based on `label` prop being present