### PR TITLE
#7247 feature: styles RadioInput

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -36,6 +36,7 @@
 @import './src/components/NewsletterSignup/newsletter-signup';
 @import './src/components/PageHeader/page-header';
 @import './src/components/Quote/quote';
+@import './src/components/RadioInput/radio-input';
 @import './src/components/ResultsItem/pagination';
 @import './src/components/ResultsItem/results-item';
 @import './src/components/ResultsItem/results-list';

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -35,9 +35,8 @@ export const RadioInput = forwardRef(
 
     return label ? (
       <div className={classNames}>
-        <Label text={label} htmlFor={id} className="cc-radio-input__label" />
         <input
-          className="cc-radio-input__toggle"
+          className="cc-radio-input__input-element"
           id={id}
           name={name}
           ref={ref}
@@ -45,6 +44,7 @@ export const RadioInput = forwardRef(
           type="radio"
           value={value}
         />
+        <Label text={label} htmlFor={id} className="cc-radio-input__label" />
       </div>
     ) : (
       <input

--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -1,0 +1,63 @@
+// ----------------------------------
+// UI Components
+// RadioInput
+// ----------------------------------
+// Design System 1.0 Alpha
+// 2019-11-11
+// ----------------------------------
+
+.cc-radio-input__label {
+  --radio-width: calc(2 * var(--space-unit));
+  --radio-inner-width: calc(0.75 * var(--space-unit));
+
+  cursor: pointer;
+  padding-left: calc(var(--radio-width) + var(--space-md));
+  position: relative;
+
+  &:after,
+  &:before {
+    @include middle(y, absolute);
+
+    background-color: var(--colour-white);
+    border: 1px solid var(--colour-grey-20);
+    border-radius: 50%;
+    content: '';
+    height: var(--radio-width);
+    left: 0;
+    width: var(--radio-width);
+  }
+
+  &:after {
+    box-shadow: inset 0 0 0 0;
+    height: var(--radio-inner-width);
+    left: calc((var(--radio-width) - var(--radio-inner-width)) / 2);
+    opacity: 0;
+    transition: opacity 0.2s, transform 0.2s;
+    width: var(--radio-inner-width);
+  }
+
+  // Checked Radio
+  .cc-radio-input__input-element:checked ~ &:after,
+  .cc-radio-input__input-element:checked ~ &:before {
+    border: 0;
+  }
+
+  .cc-radio-input__input-element:checked ~ &:before {
+    background-color: var(--colour-blue-60);
+  }
+
+  .cc-radio-input__input-element:checked ~ &:after {
+    opacity: 1;
+  }
+
+  // Hovered/Focused Radio
+  &:hover:before,
+  .cc-radio-input__input-element:focus ~ &:before {
+    border-color: var(--colour-blue-60);
+  }
+}
+
+// Hide the <input /> element
+.cc-radio-input__input-element {
+  @extend %visually-hidden;
+}


### PR DESCRIPTION
Relates to https://github.com/wellcometrust/corporate/issues/7247

- styles RadioInput
- re-orders DOM of RadioInput (moves `<label>` after `<input />`)
  - allows for use of adjacent sibling combinator `~` in styles
- renames `cc-radio-input__toggle` selector (to `cc-radio-input__input-element` for clearer comprehension
