### PR TITLE
#7297 bug: fixed breaking gallery lightbox caused by attempted string…

### DIFF
--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -39,11 +39,11 @@ const setExternalLinkMarkers = (children: React.ReactNode) => {
 };
 
 export const RichText = ({ children }: RichTextProps) => {
-  const childrenWithMarkers = setExternalLinkMarkers(children);
+  const childrenWithMarkers = children && setExternalLinkMarkers(children);
 
-  return (
+  return childrenWithMarkers ? (
     <div className="cc-rich-text">{ReactHtmlParser(childrenWithMarkers)}</div>
-  );
+  ) : null;
 };
 
 export default RichText;


### PR DESCRIPTION
… caused by attempted string replace operation on non-existent gallery text

Relates to [7297](https://github.com/wellcometrust/corporate/issues/7297) point 1