### PR TITLE
#7383 feat: Add accordion with annual reports to reports page

### DIFF
--- a/src/components/Listing/ListingLink/ListingLink.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.tsx
@@ -10,16 +10,22 @@ type ListingLinkProps = {
   fileMeta?: FileMetaProps;
   href: string;
   title: string;
+  iconVariant?: 'chevron' | 'download';
 };
 
 export const ListingLink = ({
   className,
   fileMeta,
   href,
-  title
+  title,
+  iconVariant = 'chevron'
 }: ListingLinkProps) => {
   const classNames = cx('cc-listing__item', {
     [`${className}`]: className
+  });
+
+  const iconClassNames = cx('cc-listing__link-icon', {
+    'cc-listing__link-icon--download': iconVariant === 'download'
   });
 
   return (
@@ -34,7 +40,7 @@ export const ListingLink = ({
             </span>
           </>
         )}
-        <Icon name="chevron" className="cc-listing__link-icon" />
+        <Icon name={iconVariant} className={iconClassNames} />
       </Link>
     </li>
   );

--- a/src/components/Listing/ListingLink/ListingLink.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.tsx
@@ -25,7 +25,7 @@ export const ListingLink = ({
   });
 
   const iconClassNames = cx('cc-listing__link-icon', {
-    'cc-listing__link-icon--download': iconVariant === 'download'
+    [`cc-listing__link-icon--${iconVariant}`]: iconVariant
   });
 
   return (

--- a/src/components/Listing/_listing.scss
+++ b/src/components/Listing/_listing.scss
@@ -9,11 +9,11 @@
 .cc-card-listing,
 .cc-listing {
   @include grid-column(1, 7);
-  
+
   @include mq(sm) {
     @include grid-column(2, 12);
   }
-  
+
   @include mq(md) {
     @include grid-column(4, 10);
   }
@@ -24,7 +24,7 @@
   border-bottom: 1px solid var(--colour-grey-10);
   width: 100%;
 }
-  
+
 .cc-listing__item {
   border-top: 1px solid var(--colour-grey-10);
   display: block;
@@ -55,6 +55,10 @@
   width: 0.375em;
 }
 
+.cc-listing__link-icon--download {
+  width: auto;
+}
+
 // Arrange horizontal cards in a row above `md` breakpoint
 .cc-card-listing--horizontal {
   @include mq(md) {
@@ -64,7 +68,7 @@
     flex-wrap: wrap;
     margin: -$grid-gutter-md / 2;
   }
-  
+
   // increase grid spacing
   @include mq(xl) {
     margin: -$grid-gutter-xl / 2;


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7383

Update ListingList to accept download variant.

I am reusing this component in the body of accordion on reports pages to build links to annual reports documents.

<img width="743" alt="Screenshot 2020-09-30 at 10 28 09" src="https://user-images.githubusercontent.com/10700103/94668283-c209ab00-0307-11eb-9a51-29d0ef5164f2.png">


 