### PR TITLE
bug(style): Increased ul and ol left hand indent ...

### DIFF
--- a/src/assets/styles/20-tools/_extends/_typography.scss
+++ b/src/assets/styles/20-tools/_extends/_typography.scss
@@ -119,7 +119,7 @@
 
 %list-base {
   margin: 0 0 calc(4 * var(--space-unit));
-  padding-left: calc(2.5 * var(--space-unit));
+  padding-left: calc(4 * var(--space-unit));
 
   ol,
   ul {


### PR DESCRIPTION
… to prevent ordered list numbers being obscured when into double figures

For context, rich text areas have overflow-x auto applied to allow for table data to be accessed on narrower screens