### PR TITLE
#7394 bug(style): fixes grid overflow

### DIFF
--- a/src/components/Grid/Cell/_grid-cell.scss
+++ b/src/components/Grid/Cell/_grid-cell.scss
@@ -9,6 +9,11 @@
 .grid__cell {
   @include grid-column(1, 7);
 
+  // Ensures .grid__cell will not expand beyond it's designated
+  // column boundaries
+  max-width: 100%;
+  overflow-x: auto;
+
   // IE row placement fix
   @include mq($until: md) {
     @include grid-row-auto(3, true);


### PR DESCRIPTION
See https://github.com/wellcometrust/corporate/issues/7394

- adds max-width & overflow-x style attributes to .grid__cell to prevent overflow