### PR TITLE
#7395 feat: updates prop name + selectors for Accordion border styles

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -6,17 +6,17 @@ import AccordionItem from './AccordionItem';
 type AccordionProps = {
   children?: JSX.Element | JSX.Element[];
   className?: string;
-  inPageSection?: boolean;
+  hasBorders?: boolean;
 };
 
 export const Accordion = ({
   children,
   className,
-  inPageSection
+  hasBorders
 }: AccordionProps) => {
   const [active, setActive] = useState(-1);
   const classNames = cx('cc-accordion', {
-    'cc-accordion--in-page-section': inPageSection,
+    'cc-accordion--has-borders': hasBorders,
     [`${className}`]: className
   });
 

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -12,9 +12,17 @@
 
 // .cc-accordion {}
 
-.cc-accordion--in-page-section {
+.cc-accordion--has-borders {
   border-bottom: 1px solid var(--colour-grey-10);
   border-top: 1px solid var(--colour-grey-10);
+
+  /**
+   * #7365 todo: group related accordion nodes; once done, we can
+   * start to style based on :<nth>-child pseudo selectors
+   */
+  & + & {
+    border-top: 0;
+  }
 }
 
 // .cc-accordion-item {}


### PR DESCRIPTION
See https://github.com/wellcometrust/corporate/issues/7395

- updates prop name for adding Accordion border styles (inPageSection -> hasBorders)
- updates styles to prevent sibling `.cc-accordion` elements having duplicate borders