### PR TITLE
#7444 feat(style): updates .grid__cell to span full-width on tablet

### DIFF
--- a/src/components/Grid/Cell/_grid-cell.scss
+++ b/src/components/Grid/Cell/_grid-cell.scss
@@ -20,7 +20,7 @@
   }
 
   @include mq(sm) {
-    @include grid-column(2, 12);
+    @include grid-column(1, 13);
   }
 }
 


### PR DESCRIPTION
See wellcometrust/corporate/issues/7444

- sets .grid__cell to span full column width of parent grid from `sm` breakpoint