### PR TITLE
#7426 feat: decode html entities in ResultItem title

### DIFF
--- a/src/components/ResultsItem/ResultsItem.tsx
+++ b/src/components/ResultsItem/ResultsItem.tsx
@@ -4,6 +4,8 @@ import cx from 'classnames';
 import FileDownload from 'FileDownload';
 import FormattedDate from 'FormattedDate';
 
+import { parseHtml } from 'utils/parse-html';
+
 type ResultItemMetaProps = {
   date?: string;
   lastUpdated?: string;
@@ -83,10 +85,10 @@ export const ResultsItem = ({
       )}
       <h3 className="result-item__title">
         {type === 'file' ? (
-          `${title}`
+          parseHtml(title)
         ) : (
           <a href={href} className="result-item__link">
-            {title}
+            {parseHtml(title)}
           </a>
         )}
       </h3>

--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import cx from 'classnames';
 
-// polyfill and type definitions for String.prototype.replaceAll()
-import 'ts-replace-all';
-import ReactHtmlParser from 'react-html-parser';
-
 import { ExternalLinkMarker } from 'Link';
+
+import { parseHtml } from 'utils/parse-html';
 
 type RichTextProps = {
   children: string;
@@ -65,7 +63,7 @@ export const RichText = ({
   });
 
   return childrenWithMarkers ? (
-    <div className={classNames}>{ReactHtmlParser(childrenWithMarkers)}</div>
+    <div className={classNames}>{parseHtml(childrenWithMarkers)}</div>
   ) : null;
 };
 

--- a/src/utils/parse-html.ts
+++ b/src/utils/parse-html.ts
@@ -1,0 +1,23 @@
+/**
+ * @file HTML Parser utility.
+ */
+import 'ts-replace-all';
+import ReactHtmlParser, { Options } from 'react-html-parser';
+
+/**
+ * Parse some HTML using the ReactHtmlParser lib.
+ *
+ * Decodes HTML entities, strips out <script> tags to prevent XSS
+ * attacks.
+ *
+ * @see {@link https://github.com/wrakky/react-html-parser}
+ *
+ * @param {string} html
+ * @param {object} options
+ *
+ * @returns {ReactElement}
+ */
+export const parseHtml = (html: string, options?: Options) =>
+  ReactHtmlParser(html, options);
+
+export default parseHtml;

--- a/src/utils/parse-html.ts
+++ b/src/utils/parse-html.ts
@@ -1,6 +1,8 @@
 /**
  * @file HTML Parser utility.
  */
+
+// polyfill and type definitions for String.prototype.replaceAll()
 import 'ts-replace-all';
 import ReactHtmlParser, { Options } from 'react-html-parser';
 


### PR DESCRIPTION
Solves wellcometrust/corporate/issues/7426

- adds html-parser util as wrapper for ReactHtmlParser
- updates ReactHtmlParser usage across app to use new util instead