### PR TITLE
Correct some outdated domain URLs

### DIFF
--- a/src/components/Contact/Contact.test.tsx
+++ b/src/components/Contact/Contact.test.tsx
@@ -6,7 +6,7 @@ import Contact from './Contact';
 describe('<Contact />', () => {
   const output = shallow(
     <Contact
-      email="s.pritchard@wellcome.ac.uk"
+      email="s.pritchard@wellcome.org"
       institution="Stuart's Institute"
       name="Stuart Pritchard"
       contactRole="<p>EU and Public Affairs Manager</p>"

--- a/src/components/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/NewsletterForm/NewsletterForm.tsx
@@ -77,7 +77,7 @@ export const NewsletterForm = ({
 
     const response = await fetchNewsletterResponse(
       // TODO: #6023 - move to .env
-      'https://wellcome.ac.uk/newsletter-signup',
+      'https://wellcome.org/newsletter-signup',
       email,
       type,
       dropdown

--- a/src/components/PageHeader/PageHeader.stories.tsx
+++ b/src/components/PageHeader/PageHeader.stories.tsx
@@ -77,7 +77,7 @@ const PageHeaderExample = () => {
     <SocialShare
       body="Wellcome Trust share text ..."
       title="Wellcome Trust"
-      url="https://wellcome.ac.uk"
+      url="https://wellcome.org"
     />
   );
 

--- a/src/components/SiteAlert/SiteAlert.stories.tsx
+++ b/src/components/SiteAlert/SiteAlert.stories.tsx
@@ -6,7 +6,7 @@ import SiteAlert from 'SiteAlert';
 
 const SiteAlertExample = () => {
   const isActive = boolean('isActive', true);
-  const urlString = text('url', 'https://wellcome.ac.uk/');
+  const urlString = text('url', 'https://wellcome.org/');
   const textString = text('text', 'Visit the Wellcome Trust website');
 
   return <SiteAlert isActive={isActive} text={textString} url={urlString} />;

--- a/src/components/SiteAlert/SiteAlert.test.tsx
+++ b/src/components/SiteAlert/SiteAlert.test.tsx
@@ -9,7 +9,7 @@ describe('<SiteAlert />', () => {
     <SiteAlert
       isActive
       text="Visit the Wellcome Trust website"
-      url="https://wellcome.ac.uk/"
+      url="https://wellcome.org/"
     />
   );
 

--- a/src/components/SocialShare/SocialShare.stories.tsx
+++ b/src/components/SocialShare/SocialShare.stories.tsx
@@ -12,7 +12,7 @@ const SocialShareExample = () => {
       body="Share body text"
       hasCopyLink={hasCopyLink}
       title="Share title"
-      url="https://wellcome.ac.uk"
+      url="https://wellcome.org"
     />
   );
 };

--- a/src/components/SocialShare/SocialShare.tsx
+++ b/src/components/SocialShare/SocialShare.tsx
@@ -81,7 +81,7 @@ export const SocialShare = ({
         </li>
         <li className="cc-social-share__item">
           <a
-            href={`mailto:?subject=Shared%20from%20Wellcome%3A%20${titleText}&body=${bodyText}%0d%0a%0d%0a${url}&utm_source=emailShare %0A%0A---%0A%0ASign up to the Wellcome newsletter: https://wellcome.ac.uk/newsletters/subscribe-to-wellcome-newsletter-temp`}
+            href={`mailto:?subject=Shared%20from%20Wellcome%3A%20${titleText}&body=${bodyText}%0d%0a%0d%0a${url}&utm_source=emailShare %0A%0A---%0A%0ASign up to the Wellcome newsletter: https://wellcome.org/newsletters/subscribe-to-wellcome-newsletter-temp`}
             className="cc-social-share__link"
             target="_blank"
             rel="noopener noreferrer"

--- a/src/components/WellcomeCollectionBanner/WellcomeCollectionBanner.tsx
+++ b/src/components/WellcomeCollectionBanner/WellcomeCollectionBanner.tsx
@@ -22,7 +22,7 @@ export const WellcomeCollectionBanner = ({
     <div className={bannerClassName}>
       <div className="wc-banner__container">
         <a
-          href="https://wellcomecollection.org/?utm_source=wellcome&utm_medium=referral&utm_campaign=.ac.uk&utm_content=trusthomepage-text-banner"
+          href="https://wellcomecollection.org/?utm_source=wellcome&utm_medium=referral&utm_campaign=.org&utm_content=trusthomepage-text-banner"
           className="wc-banner__link no-external-marker"
           tabIndex={bannerTabIndex}
         >


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7553

The endpoint to submit the newsletter sign up to is incorrect, and fails due to CORS. 

Correct this URL (plus some others)