### PR TITLE
#6031 feat: Header nav active links 

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,6 +22,7 @@ import { RouterLinkWrapper as Link } from 'RouterLinkWrapper/RouterLinkWrapper';
 
 import navLinkData from 'data/default-site-links.json';
 import logoData from 'Logo/constants';
+import headerNav from './header-nav';
 import { useSticky } from './use-sticky';
 
 type HeaderProps = {
@@ -51,6 +52,12 @@ export const Header = ({ banner }: HeaderProps) => {
     e.preventDefault();
     toggleSearch(true);
   };
+
+  useEffect(() => {
+    headerNav(window);
+
+    return () => {};
+  }, []);
 
   useEffect(() => {
     if (!isSearchActive && logoRef.current !== null) {

--- a/src/components/Header/header-nav.ts
+++ b/src/components/Header/header-nav.ts
@@ -1,0 +1,60 @@
+/**
+ * Utility for setting active header nav links
+ *
+ * This code has been re-purposed from the Drupal 7 codebase and is intended as a short-term fix
+ *
+ * Long term the expectation is that header nav logic will be overhauled to work
+ * in a more React-centred way hooking directly into the menu APIs
+ *
+ * @param {object} window  DOM `window` object passed as an argument to prevent undefined errors
+ */
+const headerNav = (window: Window) => {
+  if (!window) return;
+
+  const path = window?.location?.pathname;
+  const navLinks = document.querySelectorAll('.nav__link');
+
+  const setActive = (link: Element) =>
+    link && !link.classList.contains('active') && link.classList.add('active');
+
+  /**
+   * Adds `subnav-active` class to body element on pages where secondary nav is visible
+   */
+  const setSubNavActive = (link: Element) =>
+    link &&
+    link.parentNode.querySelectorAll('.nav-secondary')[0] &&
+    document.body.classList.add('subnav-active');
+
+  /**
+   * Detect parent link from data-parent attribute for non-hierarchical child links
+   * e.g. About us > jobs page url is simply `/jobs` and would not be detected otherwise
+   *
+   * @param {HTMLElement} link  Context element
+   */
+  const findActiveParent = (link: HTMLAnchorElement) => {
+    const parentUrl = link.dataset.parent;
+
+    if (!parentUrl) return;
+
+    const level = parseInt(link.dataset.level, 10);
+    const parentLink = document.querySelector(
+      `.nav__link[href="${parentUrl}"][data-level="${level - 1}"`
+    );
+
+    setSubNavActive(parentLink);
+    setActive(parentLink);
+  };
+
+  const findActive = (link: HTMLAnchorElement) => {
+    if (path.indexOf(link.pathname) > -1) {
+      setActive(link);
+      setSubNavActive(link);
+
+      findActiveParent(link);
+    }
+  };
+
+  navLinks.forEach(findActive);
+};
+
+export default headerNav;


### PR DESCRIPTION
This PR provides a short-term fix to set appropriate header nav links active (both first and second levels) to resolve https://github.com/wellcometrust/corporate/issues/6031. A former corporate codebase script has been repurposed within the library Header component itself to be more self contained and maintainable.

Long-term solution would likely be an in-depth overhaul of the header nav once the Drupal 8 menu APIs are fully featured