### PR TITLE
7566 feat: updated spacing for nested bullet point

### DIFF
--- a/src/assets/styles/20-tools/_extends/_lists.scss
+++ b/src/assets/styles/20-tools/_extends/_lists.scss
@@ -35,8 +35,8 @@
 
   ol,
   ul {
-    margin-bottom: 0;
-    margin-top: var(--space-unit);
+    margin-bottom: var(--space-md);
+    margin-top: var(--space-md);
   }
 
   li:not(:last-child) {

--- a/src/assets/styles/20-tools/_extends/_lists.scss
+++ b/src/assets/styles/20-tools/_extends/_lists.scss
@@ -35,8 +35,8 @@
 
   ol,
   ul {
-    margin-bottom: var(--space-md);
-    margin-top: var(--space-md);
+    margin-bottom: calc(2 * var(--space-unit));
+    margin-top: calc(2 * var(--space-unit));
   }
 
   li:not(:last-child) {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -46,7 +46,7 @@
   }
 
   li p {
-    margin-bottom: var(--space-md);
+    margin-bottom: calc(2 * var(--space-unit));
   }
 
   table {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -22,20 +22,20 @@
     @extend %heading-large;
     letter-spacing: 0;
   }
-  
+
   h4 {
     @extend %heading-base;
     @extend %heading-regular;
     letter-spacing: 0;
   }
-  
+
   h5,
   h6 {
     @extend %heading-base;
     @extend %heading-small;
     letter-spacing: 0;
   }
-  
+
   p {
     @extend %body-large;
   }
@@ -43,6 +43,10 @@
   ol,
   ul {
     @extend %list-base;
+  }
+
+  li p {
+    margin-bottom: var(--space-md);
   }
 
   table {
@@ -62,7 +66,7 @@
     padding: calc(0.25 * var(--space-unit)) 0 calc(0.25 * var(--space-unit)) calc(2 * var(--space-unit));
     text-align: left;
   }
-  
+
   tr {
     border: solid var(--colour-grey-10);
     border-width: 1px 0;
@@ -71,24 +75,24 @@
   thead tr {
     border-bottom-width: 2px;
   }
-  
+
   tbody tr:nth-child(odd) {
     background-color: var(--colour-cyan-05);
   }
-  
+
   th,
   td {
     padding: var(--space-md) var(--space-lg);
     text-align: left;
     vertical-align: top;
   }
-  
+
   th {
     font-size: var(--body-xxs);
     font-weight: 500;
     text-transform: uppercase;
   }
-  
+
   thead th {
     padding: calc(2.5 * var(--space-unit)) var(--space-lg);
   }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7566

Fix spacing issue on the nested bullet point list

![Screenshot 2020-10-21 at 10 17 36](https://user-images.githubusercontent.com/10700103/96701073-185a8e80-1388-11eb-854f-4621ec540dee.png)

Regular list looks ok too:
![Screenshot 2020-10-21 at 10 20 42](https://user-images.githubusercontent.com/10700103/96701092-1e506f80-1388-11eb-9a32-0cdda8cd74b9.png)

