### PR TITLE
#7557 bug(style): page header compact layout spacing fixe

### DIFF
--- a/src/components/Author/_author.scss
+++ b/src/components/Author/_author.scss
@@ -26,10 +26,12 @@
   width: var(--image-size);
 
   @include mq(sm) {
-    --image-size: calc(12.5 * var(--space-unit));
+    --image-size: calc(20 * var(--space-unit));
   }
 
   @include mq(md) {
+    --image-size: calc(12.5 * var(--space-unit));
+
     margin-bottom: var(--space-lg);
     margin-right: 0;
   }

--- a/src/components/PageHeaderCompact/_page-header-compact.scss
+++ b/src/components/PageHeaderCompact/_page-header-compact.scss
@@ -51,16 +51,7 @@
   @include mq(md) {
     @include grid-column(1, 4);
 
-    /**
-     * Setting an explicit grid-row-end prevents the grid-row boundaries
-     * this element sits on from expanding with the height of the content.
-     *
-     * We've set to span 3 rows as it has 3 sibling grid-items which
-     * use .cc-page-header-compact__section--main.
-     */
-    grid-row-end: span 3;
-    -ms-grid-row-span: 3;
-
+    // Try removing this to see what happens
     grid-row-start: 1;
   }
 

--- a/src/components/PageHeaderCompact/_page-header-compact.scss
+++ b/src/components/PageHeaderCompact/_page-header-compact.scss
@@ -51,7 +51,16 @@
   @include mq(md) {
     @include grid-column(1, 4);
 
-    // Try removing this to see what happens
+    /**
+     * Setting an explicit grid-row-end prevents the grid-row boundaries
+     * this element sits on from expanding with the height of the content.
+     *
+     * We've set to span 3 rows as it has 3 sibling grid-items which
+     * use .cc-page-header-compact__section--main.
+     */
+    grid-row-end: span 3;
+    -ms-grid-row-span: 3;
+
     grid-row-start: 1;
   }
 

--- a/src/components/PageHeaderCompact/_page-header-compact.scss
+++ b/src/components/PageHeaderCompact/_page-header-compact.scss
@@ -27,12 +27,9 @@
 }
 
 .cc-page-header-compact__section {
-  margin-bottom: var(--space-xl);
-
-  @include mq(sm) {
-    margin-bottom: var(--space-lg);
-  }
+  margin-bottom: calc(4 * var(--space-unit));
 }
+
 /**
  * We're using modifier styles to set the grid-column position, once
  * the block parent selector becomes `display: grid;`
@@ -78,6 +75,20 @@
   }
 }
 
+.cc-page-header-compact__topics {
+  @include mq(sm) {
+    flex-basis: 33.33%;
+    flex-grow: 0;
+    flex-shrink: 0;
+  }
+}
+
+.cc-page-header-compact__authors {
+  @include mq($until: sm) {
+    margin-bottom: calc(4 * var(--space-unit));
+  }
+}
+
 .cc-page-header-compact__image {
   @include mq($until: sm) {
     /**
@@ -106,6 +117,15 @@
   display: flex;
   font-size: var(--body-md);
   justify-content: space-between;
+
+  @include mq(sm) {
+    padding-bottom: calc(2 * var(--space-unit));
+    /**
+     * Adds some extra distance between the tray and siblings, without
+     * wanting to confuse the generic spacing on .cc-page-header__section
+     */
+    padding-top: calc(2 * var(--space-unit));
+  }
 }
 
 /**

--- a/src/components/TagList/_tag-list.scss
+++ b/src/components/TagList/_tag-list.scss
@@ -13,6 +13,8 @@
 
 .cc-tag-list {
   @extend %list-clean;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .cc-tag {
@@ -24,8 +26,8 @@
   letter-spacing: var(--tag-text-spacing);
   line-height: 1.2;
   margin-bottom: var(--space-xs);
+  margin-right: var(--space-xs);
   min-height: calc(4.5 * var(--space-unit));
-  min-width: calc(14 * var(--space-unit));
   padding: calc(0.75 * var(--space-unit)) calc(2 * var(--space-unit));
 }
 


### PR DESCRIPTION
Various style changes to reflect the designs [here (Article halfway house on Zeplin)](https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/5f846d1ffbbb1929d7c8fcfc).

Resolves wellcometrust/corporate/issues/7557

- tweaks to PageHeaderCompact styles
- tweaks to TagList styles
- tweaks to Author styles
