### PR TITLE
#7573 feat: Text anchors (WIP)

### DIFF
--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -108,37 +108,6 @@
   > :last-child {
     margin-bottom: 0;
   }
-
-  // Handle anchors
-  //
-  // e.g. <a id="my-anchor"></a>
-  //
-  // stylelint-disable-next-line selector-no-qualifying-type
-  a[id]:not([id='']) {
-    display: block;
-    position: relative;
-    width: 0;
-  }
-  
-  // position a pseudo element for the anchor the height
-  // of the header bar above its natural position to
-  // prevent it from being obscured
-  //
-  // stylelint-disable-next-line selector-no-qualifying-type
-  a[id]:not([id='']):before {
-    content: '';
-    display: block;
-    height: var(--header-height);
-    margin-top: calc(-1 * var(--header-height));
-    pointer-events: none;
-    visibility: hidden;
-    width: 0;
-
-    @include mq(sm) {
-      height: var(--header-height-sm);
-      margin-top: calc(-1 * var(--header-height-sm));
-    }
-  }
 }
 
 .cc-rich-text-snippet {
@@ -172,3 +141,37 @@
   letter-spacing: normal;
   margin-bottom: var(--space-unit);
 }
+
+//
+// Handle anchors
+//
+// e.g. <a id="my-anchor"></a>
+//
+/* stylelint-disable selector-no-qualifying-type */
+.cc-rich-text,
+.cc-rich-text-snippet {
+  a[id]:not([id='']) {
+    display: block;
+    position: relative;
+    width: 0;
+  }
+  
+  // position a pseudo element for the anchor the height
+  // of the header bar above its natural position to
+  // prevent it from being obscured
+  a[id]:not([id='']):before {
+    content: '';
+    display: block;
+    height: var(--header-height);
+    margin-top: calc(-1 * var(--header-height));
+    pointer-events: none;
+    visibility: hidden;
+    width: 0;
+
+    @include mq(sm) {
+      height: var(--header-height-sm);
+      margin-top: calc(-1 * var(--header-height-sm));
+    }
+  }
+}
+/* stylelint-enable selector-no-qualifying-type */

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -108,6 +108,37 @@
   > :last-child {
     margin-bottom: 0;
   }
+
+  // Handle anchors
+  //
+  // e.g. <a id="my-anchor"></a>
+  //
+  // stylelint-disable-next-line selector-no-qualifying-type
+  a[id]:not([id='']) {
+    display: block;
+    position: relative;
+    width: 0;
+  }
+  
+  // position a pseudo element for the anchor the height
+  // of the header bar above its natural position to
+  // prevent it from being obscured
+  //
+  // stylelint-disable-next-line selector-no-qualifying-type
+  a[id]:not([id='']):before {
+    content: '';
+    display: block;
+    height: var(--header-height);
+    margin-top: calc(-1 * var(--header-height));
+    pointer-events: none;
+    visibility: hidden;
+    width: 0;
+
+    @include mq(sm) {
+      height: var(--header-height-sm);
+      margin-top: calc(-1 * var(--header-height-sm));
+    }
+  }
 }
 
 .cc-rich-text-snippet {


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7573

- fix to force browser to scroll to position just under the header

@chriddell this is not currently fully tested or perfected but works for most cases with the main exception being IE11. I'm thinking the scroll-to utils in corporate-react could be moved to CC and incorporated here somehow, plus they should still be useable by CR, right?

Tested in Chrome, Firefox, Safari, IE11