### PR TITLE
7591 feat: remove margin for children in field hint component

### DIFF
--- a/src/components/FormFieldHint/_form-field-hint.scss
+++ b/src/components/FormFieldHint/_form-field-hint.scss
@@ -7,9 +7,11 @@
 // ----------------------------------
 
 .cc-form-field-hint {
-  @extend %rte;
-
   color: var(--text-colour);
   font-size: var(--body-md);
   margin-bottom: var(--space-xs);
+
+  p {
+    margin: 0;
+  }
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7591

Update style for field hint component as per design: https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/5f9196d1ae4d361e9406416b

![Screenshot 2020-10-23 at 15 04 52](https://user-images.githubusercontent.com/10700103/97013621-243d8080-1541-11eb-9d15-3305e7617301.png)
