### PR TITLE
7593 feat: hover state on forms

### DIFF
--- a/src/assets/styles/20-tools/_extends/_forms.scss
+++ b/src/assets/styles/20-tools/_extends/_forms.scss
@@ -47,7 +47,7 @@
 %text-input-base {
   @extend %text-input-reset;
 
-  border: 1px solid var(--colour-grey-20);
+  border: 1px solid var(--colour-grey-60);
   border-radius: calc(0.25 * var(--space-unit));
   display: block;
   letter-spacing: var(--body-letter-spacing);

--- a/src/components/Label/_label.scss
+++ b/src/components/Label/_label.scss
@@ -10,4 +10,12 @@
   color: var(--colour-grey-90);
   display: block;
   margin-bottom: var(--space-xs);
+
+  // don't show hover state on input when hovering on label
+  &:hover ~ input,
+  &:hover ~ select,
+  &:hover ~ textarea {
+    // border colour has to match %text-input-base
+    border: 1px solid var(--colour-grey-60);
+  }
 }

--- a/src/components/Label/_label.scss
+++ b/src/components/Label/_label.scss
@@ -16,6 +16,6 @@
   &:hover ~ select,
   &:hover ~ textarea {
     // border colour has to match %text-input-base
-    border: 1px solid var(--colour-grey-60);
+    border-color: var(--colour-grey-60);
   }
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7593

Implement Fahim's feedback https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/5f9184937b1b2d8faeef2ff7
- Default border colour for textfield should be #grey-60-767676
- Hover colour for textfield should be #black
- Only activate hover state when hovering over the textfield

An interesting fact about the labels and inputs that I learnt today [source](https://www.kizu.ru/label-to-input/
):
> [...] when you declare a state for an input in CSS, like with`:hover`or `:active` pseudo classes, and then you have a label for that input, then triggering those states over the label would actually trigger the same states on the input.

