### PR TITLE
#7599 feat: text listing should not show author

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,20 +3,29 @@ import cx from 'classnames';
 
 import FormattedDate from 'FormattedDate';
 import ImageElement from 'Image/ImageElement';
-import { CardBaseProps } from 'ResultsItem/ResultsItem';
 
-export type CardImageProps = {
-  alt?: string;
-  src?: string;
-  // sources?: {
-  //   thumbnail_lo?: string;
-  //   thumbnail?: string;
-  //   thumbnail_hi?: string;
-  // };
-};
-
-export type CardProps = CardBaseProps & {
-  image?: CardImageProps;
+type CardProps = {
+  authors?: string[];
+  className?: string;
+  description?: string;
+  href: string;
+  id?: string;
+  image?: {
+    alt?: string;
+    src?: string;
+    // sources?: {
+    //   thumbnail_lo?: string;
+    //   thumbnail?: string;
+    //   thumbnail_hi?: string;
+    // };
+  };
+  meta?: {
+    date?: string;
+    lastUpdated?: string;
+    hasType?: boolean;
+    type?: string | null;
+  };
+  title: string;
   variant: 'horizontal_card' | 'link_list' | 'text_list' | 'vertical_card';
 };
 

--- a/src/components/Listing/ListingElement/ListingElement.tsx
+++ b/src/components/Listing/ListingElement/ListingElement.tsx
@@ -3,11 +3,35 @@ import cx from 'classnames';
 
 import Card from 'Card';
 import { ListingLink } from 'Listing/ListingLink/ListingLink';
-import ResultsItem, { ResultItemProps } from 'ResultsItem/ResultsItem';
-import { CardImageProps } from 'Card/Card';
+import ResultsItem from 'ResultsItem/ResultsItem';
 
-type ListingElementProps = ResultItemProps & {
-  image?: CardImageProps;
+type ListingElementProps = {
+  authors?: string[];
+  className?: string;
+  description?: string;
+  href: string;
+  id?: string;
+  image?: {
+    alt?: string;
+    src?: string;
+    // sources?: {
+    //   thumbnail_lo?: string;
+    //   thumbnail?: string;
+    //   thumbnail_hi?: string;
+    // };
+  };
+  meta?: {
+    date?: string;
+    lastUpdated?: string;
+    hasType?: boolean;
+    type?: string | null;
+  };
+  title: string;
+  fileMeta?: {
+    type: string;
+    size: string;
+  };
+  type?: 'content' | 'file' | 'taxonomy_term';
   variant: 'horizontal_card' | 'link_list' | 'text_list' | 'vertical_card';
 };
 

--- a/src/components/Listing/ListingLink/ListingLink.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import cx from 'classnames';
 
-import { FileMetaProps } from 'ResultsItem/ResultsItem';
 import Icon from 'Icon';
 import Link from 'Link';
 
 type ListingLinkProps = {
   className?: string;
-  fileMeta?: FileMetaProps;
+  fileMeta?: {
+    type: string;
+    size: string;
+  };
   href: string;
   title: string;
   iconVariant?: 'chevron' | 'download';

--- a/src/components/ResultsItem/ResultsItem.tsx
+++ b/src/components/ResultsItem/ResultsItem.tsx
@@ -20,7 +20,6 @@ export type FileMetaProps = {
 };
 
 export type CardBaseProps = {
-  authors?: string[];
   className?: string;
   description?: string;
   href: string;
@@ -35,7 +34,6 @@ export type ResultItemProps = CardBaseProps & {
 };
 
 export const ResultsItem = ({
-  authors,
   className,
   description,
   fileMeta,
@@ -106,16 +104,6 @@ export const ResultsItem = ({
         <RichText className="cc-result-item__description">
           {description}
         </RichText>
-      )}
-      {authors && (
-        <dl className="cc-card__authors">
-          <dt className="cc-card__authors-label">Author</dt>
-          {authors?.map(author => (
-            <dd key={author} className="cc-card__author">
-              {author}
-            </dd>
-          ))}
-        </dl>
       )}
     </article>
   );

--- a/src/components/ResultsItem/ResultsItem.tsx
+++ b/src/components/ResultsItem/ResultsItem.tsx
@@ -7,29 +7,22 @@ import FormattedDate from 'FormattedDate';
 import { parseHtml } from 'utils/parse-html';
 import RichText from 'RichText';
 
-type ResultItemMetaProps = {
-  date?: string;
-  lastUpdated?: string;
-  hasType?: boolean;
-  type?: string | null;
-};
-
-export type FileMetaProps = {
-  type: string;
-  size: string;
-};
-
-export type CardBaseProps = {
+type ResultItemProps = {
   className?: string;
   description?: string;
   href: string;
   id?: string;
-  meta?: ResultItemMetaProps;
+  meta?: {
+    date?: string;
+    lastUpdated?: string;
+    hasType?: boolean;
+    type?: string | null;
+  };
   title: string;
-};
-
-export type ResultItemProps = CardBaseProps & {
-  fileMeta?: FileMetaProps;
+  fileMeta?: {
+    type: string;
+    size: string;
+  };
   type?: 'content' | 'file' | 'taxonomy_term';
 };
 


### PR DESCRIPTION
See wellcometrust/corporate/issues/7599

- removes `authors` prop from `ResultItem` component
- untangles related/exported types in `ResultsItem`, `Card` and `ListingLink` components
- updates instances of `ResultItem` to `ResultsItem`