### PR TITLE
7645 feat: add contactForm prop to InfoBox

### DIFF
--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -15,7 +15,7 @@ type ContactProps = {
   className?: string;
   contactFormLink?: {
     text?: string;
-    url?: string;
+    url: string;
   };
   email?: string;
   imageSources?: ContactImageSourceProps;

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -22,7 +22,7 @@ type ContactProps = {
   institution?: string;
   institutionCountry?: string;
   contactRole?: string;
-  name: string;
+  name?: string;
   teamTitle?: string;
   teamUrl?: string;
   tel?: string;
@@ -56,9 +56,11 @@ export const Contact = ({
           // srcSet={srcSet}
         />
       )}
-      <h3 className="cc-contact__name" itemProp="name">
-        {name}
-      </h3>
+      {name && (
+        <h3 className="cc-contact__name" itemProp="name">
+          {name}
+        </h3>
+      )}
       {contactRole && (
         <RichText className="cc-contact__role" variant="text-snippet">
           {contactRole}

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -13,8 +13,8 @@ type ContactImageSourceProps = {
 
 type ContactProps = {
   className?: string;
-  contactForm?: {
-    title?: string;
+  contactFormLink?: {
+    text?: string;
     url?: string;
   };
   email?: string;
@@ -30,7 +30,7 @@ type ContactProps = {
 
 export const Contact = ({
   className,
-  contactForm,
+  contactFormLink,
   email,
   imageSources,
   institution,
@@ -89,11 +89,11 @@ export const Contact = ({
           </a>
         </p>
       )}
-      {contactForm && (
+      {contactFormLink && (
         <p className="cc-contact__item">
           <Icon name="email" className="cc-contact__link-icon" />
-          <a href={`${contactForm.url}`} className="cc-contact__link">
-            {contactForm.title}
+          <a href={`${contactFormLink.url}`} className="cc-contact__link">
+            {contactFormLink.text || 'Send a message'}
           </a>
         </p>
       )}

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -13,6 +13,10 @@ type ContactImageSourceProps = {
 
 type ContactProps = {
   className?: string;
+  contactForm?: {
+    title?: string;
+    url?: string;
+  };
   email?: string;
   imageSources?: ContactImageSourceProps;
   institution?: string;
@@ -26,6 +30,7 @@ type ContactProps = {
 
 export const Contact = ({
   className,
+  contactForm,
   email,
   imageSources,
   institution,
@@ -79,6 +84,14 @@ export const Contact = ({
           <Icon name="email" className="cc-contact__link-icon" />
           <a href={`mailto:${email}`} className="cc-contact__link">
             {email}
+          </a>
+        </p>
+      )}
+      {contactForm && (
+        <p className="cc-contact__item">
+          <Icon name="email" className="cc-contact__link-icon" />
+          <a href={`${contactForm.url}`} className="cc-contact__link">
+            {contactForm.title}
           </a>
         </p>
       )}


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7645

The current Contact us has an option to send a message. It is a form not an email

<img width="799" alt="Screenshot 2020-10-28 at 13 03 53" src="https://user-images.githubusercontent.com/10700103/97439630-4d358b00-191e-11eb-8a4b-10ad1d7800c3.png">

link: https://wellcome.org/grant-funding/guidance-listing

I have decided to implement this by adding `contactForm` to `InfoBox` component

<img width="692" alt="Screenshot 2020-10-28 at 13 14 05" src="https://user-images.githubusercontent.com/10700103/97440719-b9fd5500-191f-11eb-8d5d-7f31c61e543a.png">

Please let me know if this is the correct way