### PR TITLE
#7653 bug: fixes table overflow-x scroll 

### DIFF
--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import { ExternalLinkMarker } from 'Link';
 
 import { parseHtml } from 'utils/parse-html';
+import { format } from 'path';
 
 type RichTextProps = {
   children: string;
@@ -29,28 +30,51 @@ type RichTextProps = {
 // TODO: replace `non` with class name to be ignored
 const regexAnchorExternal = /(?!.*class="non")(?!.*href="https?:\/\/(?:www\.)?wellcome.(?:org|ac\.uk).*".*)(?!.*href="mailto:)(<a[^>]*target="_blank"[^>]*>)([^<]+)(<\/a>)/g;
 
-/**
- * Add markup to all anchor elements which open in a new window
- * to indicate an external link
- *
- * @param children
- */
-const addExternalLinkMarkers = (children: string) => {
-  // renderToStaticMarkup used to preserve svg attributes in JSX format for re-rendering
-  const externalMarker = renderToStaticMarkup(<ExternalLinkMarker />);
+const regexTableElements = /<table(.*?)>(.|\n)(.*?)(.|\n)*<\/table>/g;
 
-  return children.replaceAll(regexAnchorExternal, (match, p1, p2, p3) =>
-    // replace existing anchor string with embellished version containing assistive text
-    // p[n] refers to each group within the match - groups are defined within parentheses
-    // p1 and p2 are contained in the 2nd negative lookup
-    // so we start with p3 as the first actual string
-    p1
-      ? `${p1.substring(
-          0,
-          p1.length - 1
-        )} rel="nofollow noreferrer" class="u-link-new-window">${p2}${externalMarker}${p3}`
-      : match
-  );
+/**
+ * Perform some desirable transforms to a string of HTML so that we
+ * can affect the markup however we desire.
+ *
+ * @param {string} children
+ * @returns {string}
+ */
+const formatHTMLString = (children: string) => {
+  try {
+    // renderToStaticMarkup used to preserve svg attributes in JSX format for re-rendering
+    const externalMarker = renderToStaticMarkup(<ExternalLinkMarker />);
+
+    return (
+      children
+        /**
+         * Add markup to all anchor elements which open in a new window
+         * to indicate an external link
+         */
+        .replaceAll(regexAnchorExternal, (match, p1, p2, p3) =>
+          // replace existing anchor string with embellished version containing assistive text
+          // p[n] refers to each group within the match - groups are defined within parentheses
+          // p1 and p2 are contained in the 2nd negative lookup
+          // so we start with p3 as the first actual string
+          p1
+            ? `${p1.substring(
+                0,
+                p1.length - 1
+              )} rel="nofollow noreferrer" class="u-link-new-window">${p2}${externalMarker}${p3}`
+            : match
+        )
+
+        /**
+         * Add markup to wrap <table> elements with a <div> to prevent overflow-x
+         * on the rich-text element, constraining the overflow-x to only the
+         * <table> element itself.
+         */
+        .replaceAll(regexTableElements, match => {
+          return `<div class="cc-rich-text__table-wrap">${match}</div>`;
+        })
+    );
+  } catch {
+    return children;
+  }
 };
 
 export const RichText = ({
@@ -58,14 +82,12 @@ export const RichText = ({
   className,
   variant = 'text'
 }: RichTextProps) => {
-  const childrenWithMarkers = children && addExternalLinkMarkers(children);
+  const htmlString = formatHTMLString(children);
   const classNames = cx(`cc-rich-${variant}`, {
     [className]: className
   });
 
-  return childrenWithMarkers ? (
-    <div className={classNames}>{parseHtml(childrenWithMarkers)}</div>
-  ) : null;
+  return <div className={classNames}>{parseHtml(htmlString)}</div>;
 };
 
 export default RichText;

--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -5,7 +5,6 @@ import cx from 'classnames';
 import { ExternalLinkMarker } from 'Link';
 
 import { parseHtml } from 'utils/parse-html';
-import { format } from 'path';
 
 type RichTextProps = {
   children: string;

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -7,7 +7,6 @@
 // ----------------------------------
 
 .cc-rich-text {
-
   // ensure extra long words are wrapped to prevent overlap or horizontal scroll
   overflow-wrap: break-word;
   // ensure wide table data can be seen using horizontal scroll
@@ -56,8 +55,10 @@
   table {
     border-collapse: collapse;
     caption-side: top;
+    display: block;
     line-height: var(--body-line-height-sm);
     margin-bottom: calc(4 * var(--space-unit));
+    overflow-x: scroll;
     width: 100%;
   }
 

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -55,10 +55,8 @@
   table {
     border-collapse: collapse;
     caption-side: top;
-    display: block;
     line-height: var(--body-line-height-sm);
     margin-bottom: calc(4 * var(--space-unit));
-    overflow-x: scroll;
     width: 100%;
   }
 
@@ -141,4 +139,9 @@
   font-weight: bold;
   letter-spacing: normal;
   margin-bottom: var(--space-unit);
+}
+
+.cc-rich-text__table-wrap {
+  overflow-x: scroll;
+  width: 100%;
 }


### PR DESCRIPTION
See wellcometrust/corporate/issues/7653

- wraps `<table>` elements inside RichText with a `<div>`
- adds style hook for overflow-x to scroll for the `<table>`