### PR TITLE
#7749 feat: adds ImageCardMultiple storybook story

### DIFF
--- a/src/components/ImageCard/ImageCard.stories.tsx
+++ b/src/components/ImageCard/ImageCard.stories.tsx
@@ -69,6 +69,15 @@ const MultipleImageCard = () => {
   return (
     <div
       style={{
+        /**
+         * todo: Render ImageCard with Listing
+         *
+         * This will mean we can render multiple ImageCard components
+         * by passing the data to the Listing component, and move the styles
+         * + DOM from here to be handled by that component + Sass (for the styles)
+         *
+         * @see {@link https://github.com/wellcometrust/corporate/issues/7750}
+         */
         display: 'flex',
         justifyContent: 'space-between',
         flexWrap: 'nowrap',

--- a/src/components/ImageCard/ImageCard.stories.tsx
+++ b/src/components/ImageCard/ImageCard.stories.tsx
@@ -4,7 +4,7 @@ import { select, text } from '@storybook/addon-knobs';
 
 import ImageCard from './ImageCard';
 
-const ImageCardExample = () => {
+const SingleImageCard = () => {
   const authors = text(
     'authors',
     'Christiane Hertz-Fowler, Georgia Walton, Chonnettia Jones'
@@ -39,6 +39,71 @@ const ImageCardExample = () => {
   );
 };
 
-const stories = storiesOf('Components|ImageCard', module);
+const MultipleImageCard = () => {
+  const cardCount = select('How many ImageCards?', [2, 3], 3, 'General');
 
-stories.add('ImageCard', ImageCardExample);
+  const knobs = [...Array(cardCount).keys()].map(i => ({
+    authors: text(
+      'authors',
+      'Christiane Hertz-Fowler, Georgia Walton, Chonnettia Jones',
+      `Card ${i + 1}`
+    ),
+    date: text('Date', '03/08/1991', `Card ${i + 1}`),
+    imageAlt: text('Image alt text', 'Alternative image text', `Card ${i + 1}`),
+    imageSrc: text(
+      'Image path',
+      `https://via.placeholder.com/300`,
+      `Card ${i + 1}`
+    ),
+    title: text('Title', 'My section', `Card ${i + 1}`),
+    titleAs: select(
+      'Title element',
+      ['h2', 'h3', 'h4', 'h5', 'h6'],
+      'h3',
+      `Card ${i + 1}`
+    ),
+    topic: text('Topic', 'Climate Change', `Card ${i + 1}`),
+    url: text('URL', '/news/all', `Card ${i + 1}`)
+  }));
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        flexWrap: 'nowrap',
+        marginLeft: 'calc(-1 * var(--space-xl))'
+      }}
+    >
+      {[...Array(cardCount).keys()].map(i => (
+        <div
+          style={{
+            flexBasis: '33.33%',
+            flexGrow: 1,
+            marginBottom: 'var(--space-unit)',
+            marginLeft: 'var(--space-xl)'
+          }}
+        >
+          <ImageCard
+            authors={knobs[i].authors
+              .trim()
+              .split(',')
+              .map(a => a.trim())}
+            date={knobs[i].date}
+            imageAlt={knobs[i].imageAlt}
+            imageSrc={knobs[i].imageSrc}
+            title={knobs[i].title}
+            titleAs={knobs[i].titleAs}
+            topic={knobs[i].topic}
+            url={knobs[i].url}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const stories = storiesOf('ImageCard', module);
+
+stories.add('Single', SingleImageCard);
+stories.add('Multiple', MultipleImageCard);


### PR DESCRIPTION
This PR adds a storybook component to render multiple ImageCard components so that we can get them QA'd by design.

We do not yet have the style rules written for this, so I have used css-in-js to apply what are temporary styles which will be replicated in Sass once we implement https://github.com/wellcometrust/corporate/issues/7750

See wellcometrust/corporate/issues/7749

- adds storybook story to display multiple ImageCard components