### PR TITLE
#7750 feat: onward journey paragraph

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -35,13 +35,6 @@ const CardExample = () => {
   const image = {
     alt: text('alt', 'Image alt text', imageGroupID),
     src: text('src', 'https://placehold.it/600x342', imageGroupID)
-
-    // TODO: handle responsive image sources
-    // sources: {
-    //   thumbnail_lo: text('thumbnail_lo', 'https://placehold.it/300x171', imageGroupID),
-    //   thumbnail: text('thumbnail', 'https://placehold.it/600x342', imageGroupID),
-    //   thumbnail_hi: text('thumbnail_hi', 'https://placehold.it/900x513', imageGroupID)
-    // }
   };
 
   // Meta props
@@ -56,7 +49,8 @@ const CardExample = () => {
       className={isVertical ? 'cc-card--vertical' : 'cc-card--horizontal'}
       description={description}
       href={href}
-      image={image}
+      imageAlt={image.alt}
+      imageSrc={image.src}
       meta={meta}
       title={title}
       variant="horizontal_card"

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -47,11 +47,12 @@ const CardExample = () => {
     <Card
       authors={['Eliza Manningham-Buller', 'Jeremy Farrar']}
       className={isVertical ? 'cc-card--vertical' : 'cc-card--horizontal'}
+      date={meta.date}
       description={description}
       href={href}
       imageAlt={image.alt}
       imageSrc={image.src}
-      meta={meta}
+      metaLabel={meta.type}
       title={title}
       variant="horizontal_card"
     />

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -12,17 +12,8 @@ describe('<Card />', () => {
     <Card
       description="The true impact of the COVID-19 pandemic will be felt beyond its immediate effects. Jeremy Farrar explains why the choices leaders make now will help define the 21st century."
       href="/news/our-response-covid-19-will-help-define-21st-century"
-      image={{
-        alt: 'Image alt text',
-        src: 'https://placehold.it/600x342'
-
-        // TODO: handle responsive image sources
-        // sources: {
-        //   thumbnail_lo: 'https://placehold.it/300x171',
-        //   thumbnail: 'https://placehold.it/600x342',
-        //   thumbnail_hi: 'https://placehold.it/900x513'
-        // }
-      }}
+      imageAlt="Image alt text"
+      imageSrc="https://placehold.it/600x342"
       meta={meta}
       title="Our response to COVID-19 will help define the 21st century"
       variant="horizontal_card"

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -10,11 +10,12 @@ describe('<Card />', () => {
   };
   const output = shallow(
     <Card
+      date={meta.date}
       description="The true impact of the COVID-19 pandemic will be felt beyond its immediate effects. Jeremy Farrar explains why the choices leaders make now will help define the 21st century."
       href="/news/our-response-covid-19-will-help-define-21st-century"
       imageAlt="Image alt text"
       imageSrc="https://placehold.it/600x342"
-      meta={meta}
+      metaLabel={meta.type}
       title="Our response to COVID-19 will help define the 21st century"
       variant="horizontal_card"
     />

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -7,6 +7,7 @@ import ImageElement from 'Image/ImageElement';
 type CardProps = {
   authors?: string[];
   className?: string;
+  date?: string;
   description?: string;
   href: string;
   id?: string;
@@ -15,12 +16,7 @@ type CardProps = {
   imageSrc: string;
   imageSrcSet?: string;
   imageWidth?: string;
-  meta?: {
-    date?: string;
-    lastUpdated?: string;
-    hasType?: boolean;
-    type?: string | null;
-  };
+  metaLabel?: string;
   title: string;
   variant:
     | 'image_card'
@@ -36,6 +32,7 @@ const cardImageSizesDefault =
 export const Card = ({
   authors,
   className,
+  date,
   description,
   href,
   id,
@@ -44,7 +41,7 @@ export const Card = ({
   imageSrc,
   imageSrcSet,
   imageWidth,
-  meta,
+  metaLabel,
   title,
   variant
 }: CardProps) => {
@@ -68,15 +65,15 @@ export const Card = ({
         />
       </div>
       <div className="cc-card__content">
-        {isHorizontal && meta?.type && (
-          <p className="cc-card__type">{meta?.type}</p>
+        {isHorizontal && metaLabel && (
+          <p className="cc-card__type">{metaLabel}</p>
         )}
         <h3 className="cc-card__title">
           <a href={href} className="cc-card__link" target="_self">
             {title}
           </a>
         </h3>
-        {isHorizontal && (authors || meta?.date) && (
+        {isHorizontal && (authors || date) && (
           <div className="cc-card__meta">
             {isHorizontal && authors && (
               <dl className="cc-card__authors">
@@ -88,9 +85,9 @@ export const Card = ({
                 ))}
               </dl>
             )}
-            {isHorizontal && meta?.date && (
+            {isHorizontal && date && (
               <time className="cc-card__date">
-                <FormattedDate dateString={meta?.date} />
+                <FormattedDate dateString={date} />
               </time>
             )}
           </div>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -26,7 +26,12 @@ type CardProps = {
     type?: string | null;
   };
   title: string;
-  variant: 'horizontal_card' | 'link_list' | 'text_list' | 'vertical_card';
+  variant:
+    | 'image_card'
+    | 'horizontal_card'
+    | 'link_list'
+    | 'text_list'
+    | 'vertical_card';
 };
 
 const cardImageSizesDefault =

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -21,7 +21,9 @@ type CardProps = {
   variant:
     | 'image_card'
     | 'horizontal_card'
+    | 'link_card_cta_link'
     | 'link_list'
+    | 'mid_page_card'
     | 'text_list'
     | 'vertical_card';
 };
@@ -50,7 +52,7 @@ export const Card = ({
   });
 
   const isHorizontal = variant === 'horizontal_card';
-  const isVertical = variant === 'vertical_card';
+  const isVertical = variant === 'vertical_card' || variant === 'mid_page_card';
 
   return (
     <article className={classNames} id={id}>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -10,15 +10,11 @@ type CardProps = {
   description?: string;
   href: string;
   id?: string;
-  image?: {
-    alt?: string;
-    src?: string;
-    // sources?: {
-    //   thumbnail_lo?: string;
-    //   thumbnail?: string;
-    //   thumbnail_hi?: string;
-    // };
-  };
+  imageAlt: string;
+  imageHeight?: string;
+  imageSrc: string;
+  imageSrcSet?: string;
+  imageWidth?: string;
   meta?: {
     date?: string;
     lastUpdated?: string;
@@ -43,7 +39,11 @@ export const Card = ({
   description,
   href,
   id,
-  image,
+  imageAlt,
+  imageHeight,
+  imageSrc,
+  imageSrcSet,
+  imageWidth,
   meta,
   title,
   variant
@@ -55,23 +55,16 @@ export const Card = ({
   const isHorizontal = variant === 'horizontal_card';
   const isVertical = variant === 'vertical_card';
 
-  const src = image?.src;
-
-  // TODO: handle responsive image sources
-  // const srcSet = `
-  //     ${image?.sources?.thumbnail_lo} 300w,
-  //     ${image?.sources?.thumbnail} 600w,
-  //     ${image?.sources?.thumbnail_hi} 900w
-  //   `;
-
   return (
     <article className={classNames} id={id}>
       <div className="cc-card__image">
         <ImageElement
-          alt={image?.alt}
-          // sizes={srcSet && cardImageSizesDefault}
-          src={src}
-          // srcSet={srcSet}
+          alt={imageAlt}
+          height={imageHeight}
+          sizes={cardImageSizesDefault}
+          src={imageSrc}
+          srcSet={imageSrcSet}
+          width={imageWidth}
         />
       </div>
       <div className="cc-card__content">

--- a/src/components/ImageCard/ImageCard.stories.tsx
+++ b/src/components/ImageCard/ImageCard.stories.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { select, text } from '@storybook/addon-knobs';
 
+import Listing from 'Listing';
+
 import ImageCard from './ImageCard';
 
-const ImageCardExample = () => {
+const SingleImageCard = () => {
   const authors = text(
     'authors',
     'Christiane Hertz-Fowler, Georgia Walton, Chonnettia Jones'
@@ -17,10 +19,10 @@ const ImageCardExample = () => {
   const imageAlt = text('Image alt text', 'Alternative image text');
   const imageSrc = text('Image path', `https://via.placeholder.com/300`);
 
+  const metaLabel = text('Meta Label', 'Climate Change');
+
   const title = text('Title', 'My section');
   const titleAs = select('Title element', ['h2', 'h3', 'h4', 'h5', 'h6'], 'h3');
-
-  const metaLabel = text('metaLabel', 'Meta');
 
   return (
     <ImageCard
@@ -29,16 +31,65 @@ const ImageCardExample = () => {
         .split(',')
         .map(a => a.trim())}
       date={date}
+      href={href}
       imageAlt={imageAlt}
       imageSrc={imageSrc}
       metaLabel={metaLabel}
       title={title}
       titleAs={titleAs}
-      href={href}
     />
   );
 };
 
-const stories = storiesOf('Components|ImageCard', module);
+const MultipleImageCard = () => {
+  const cardCount = select('How many ImageCards?', [2, 3], 3, 'General');
 
-stories.add('ImageCard', ImageCardExample);
+  const knobs = [...Array(cardCount).keys()].map(i => ({
+    authors: text(
+      'authors',
+      'Christiane Hertz-Fowler, Georgia Walton, Chonnettia Jones',
+      `Card ${i + 1}`
+    ),
+    date: text('Date', '03/08/1991', `Card ${i + 1}`),
+    href: text('href', '/news/all', `Card ${i + 1}`),
+    imageAlt: text('Image alt text', 'Alternative image text', `Card ${i + 1}`),
+    imageSrc: text(
+      'Image path',
+      `https://via.placeholder.com/300`,
+      `Card ${i + 1}`
+    ),
+    metaLabel: text('Meta Label', 'Climate Change', `Card ${i + 1}`),
+    title: text('Title', 'My section', `Card ${i + 1}`),
+    titleAs: select(
+      'Title element',
+      ['h2', 'h3', 'h4', 'h5', 'h6'],
+      'h3',
+      `Card ${i + 1}`
+    )
+  }));
+
+  return (
+    <Listing variant="image_card">
+      {[...Array(cardCount).keys()].map(i => (
+        <ImageCard
+          authors={knobs[i].authors
+            .trim()
+            .split(',')
+            .map(a => a.trim())}
+          date={knobs[i].date}
+          imageAlt={knobs[i].imageAlt}
+          imageSrc={knobs[i].imageSrc}
+          title={knobs[i].title}
+          titleAs={knobs[i].titleAs}
+          metaLabel={knobs[i].metaLabel}
+          href={knobs[i].href}
+        />
+      ))}
+    </Listing>
+  );
+};
+
+const stories = storiesOf('ImageCard', module);
+
+stories.add('Single', SingleImageCard);
+stories.add('Multiple', MultipleImageCard);

--- a/src/components/ImageCard/ImageCard.stories.tsx
+++ b/src/components/ImageCard/ImageCard.stories.tsx
@@ -12,6 +12,8 @@ const ImageCardExample = () => {
 
   const date = text('Date', '03/08/1991');
 
+  const href = text('href', '/news/all');
+
   const imageAlt = text('Image alt text', 'Alternative image text');
   const imageSrc = text('Image path', `https://via.placeholder.com/300`);
 
@@ -19,8 +21,6 @@ const ImageCardExample = () => {
   const titleAs = select('Title element', ['h2', 'h3', 'h4', 'h5', 'h6'], 'h3');
 
   const metaLabel = text('metaLabel', 'Meta');
-
-  const url = text('URL', '/news/all');
 
   return (
     <ImageCard
@@ -34,7 +34,7 @@ const ImageCardExample = () => {
       metaLabel={metaLabel}
       title={title}
       titleAs={titleAs}
-      url={url}
+      href={href}
     />
   );
 };

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -6,9 +6,9 @@ import FormattedDate from 'FormattedDate';
 import Link from 'Link';
 
 type ImageCardProps = {
-  authors: string[];
+  authors?: string[];
   className?: string;
-  date: string;
+  date?: string;
   href: string;
   imageAlt: string;
   imageHeight?: string;
@@ -18,7 +18,7 @@ type ImageCardProps = {
   imageWidth?: string;
   title: string;
   titleAs?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  metaLabel: string;
+  metaLabel?: string;
 };
 
 export const ImageCard = ({
@@ -59,37 +59,43 @@ export const ImageCard = ({
         </figure>
       </Link>
       <div className="cc-image-card__body">
-        <span className="cc-image-card__meta">
-          <span className="cc-image-card__meta-item cc-image-card__meta-item--flag cc-image-card__meta-item--label">
-            {metaLabel}
+        {(metaLabel || authors?.length) && (
+          <span className="cc-image-card__meta">
+            {metaLabel && (
+              <span className="cc-image-card__meta-item cc-image-card__meta-item--flag cc-image-card__meta-item--label">
+                {metaLabel}
+              </span>
+            )}
+            {authors?.length && (
+              <dl className="cc-image-card__meta-item cc-image-card__meta-item--author cc-image-card__authors">
+                <dt className="cc-image-card__authors-label">Author</dt>
+                {authors?.map(author => (
+                  <dd
+                    key={author}
+                    className="cc-image-card__author"
+                    itemProp="author"
+                  >
+                    {author}
+                  </dd>
+                ))}
+              </dl>
+            )}
           </span>
-          {authors && (
-            <dl className="cc-image-card__meta-item cc-image-card__meta-item--author cc-image-card__authors">
-              <dt className="cc-image-card__authors-label">Author</dt>
-              {authors?.map(author => (
-                <dd
-                  key={author}
-                  className="cc-image-card__author"
-                  itemProp="author"
-                >
-                  {author}
-                </dd>
-              ))}
-            </dl>
-          )}
-        </span>
+        )}
         <TitleElement className="cc-image-card__title" itemProp="name">
           <Link className="cc-image-card__link" to={href}>
             {title}
           </Link>
         </TitleElement>
-        <time
-          className="cc-image-card__date"
-          dateTime={date}
-          itemProp="datePublished"
-        >
-          <FormattedDate dateString={date} />
-        </time>
+        {date && (
+          <time
+            className="cc-image-card__date"
+            dateTime={date}
+            itemProp="datePublished"
+          >
+            <FormattedDate dateString={date} />
+          </time>
+        )}
       </div>
     </article>
   );

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -28,7 +28,6 @@ export const ImageCard = ({
   href,
   imageAlt,
   imageHeight,
-  imageSizes,
   imageSrc,
   imageSrcSet,
   imageWidth,
@@ -53,7 +52,6 @@ export const ImageCard = ({
             alt={imageAlt}
             height={imageHeight}
             itemProp="image"
-            sizes={imageSizes}
             src={imageSrc}
             srcSet={imageSrcSet}
             width={imageWidth}

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -9,6 +9,7 @@ type ImageCardProps = {
   authors: string[];
   className?: string;
   date: string;
+  href: string;
   imageAlt: string;
   imageHeight?: string;
   imageSizes?: string;
@@ -18,13 +19,13 @@ type ImageCardProps = {
   title: string;
   titleAs?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   metaLabel: string;
-  url: string;
 };
 
 export const ImageCard = ({
   authors,
   className,
   date,
+  href,
   imageAlt,
   imageHeight,
   imageSizes,
@@ -33,8 +34,7 @@ export const ImageCard = ({
   imageWidth,
   title,
   titleAs = 'h3',
-  metaLabel,
-  url
+  metaLabel
 }: ImageCardProps) => {
   const TitleElement = titleAs;
   const classNames = cx('cc-image-card', {
@@ -47,7 +47,7 @@ export const ImageCard = ({
       itemScope
       itemType="https://schema.org/Article"
     >
-      <Link className="cc-image-card__figure" to={url}>
+      <Link className="cc-image-card__figure" to={href}>
         <figure className="cc-image-card__image">
           <ImageElement
             alt={imageAlt}
@@ -81,7 +81,7 @@ export const ImageCard = ({
           )}
         </span>
         <TitleElement className="cc-image-card__title" itemProp="name">
-          <Link className="cc-image-card__link" to={url}>
+          <Link className="cc-image-card__link" to={href}>
             {title}
           </Link>
         </TitleElement>

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -7,13 +7,24 @@
 // ----------------------------------
 
 .cc-image-card {
+  margin-bottom: var(--space-lg);
+
   @include mq($until: md) {
     display: flex;
     flex-wrap: nowrap;
   }
 
   @include mq(md) {
+    flex-basis: calc(33.33% - #{$grid-gutter-md});
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin: $grid-gutter-md / 2;
     padding-bottom: var(--space-unit);
+  }
+
+  @include mq(xl) {
+    flex-basis: calc(33.33% - #{$grid-gutter-xl});
+    margin: $grid-gutter-xl / 2;
   }
 }
 

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -57,6 +57,10 @@
   }
 }
 
+.cc-image-card__title {
+  letter-spacing: 0;
+}
+
 .cc-image-card__meta {
   align-items: center;
   display: flex;

--- a/src/components/Listing/Listing.tsx
+++ b/src/components/Listing/Listing.tsx
@@ -19,7 +19,7 @@ type ListingProps = {
 // Specific style variations for card listings
 const variantMapping = {
   horizontal_card: 'cc-card-listing cc-card-listing--horizontal',
-  image_card: 'cc-card-listing',
+  image_card: 'cc-card-listing cc-card-listing--horizontal',
   link_list: 'cc-listing',
   text_list: 'cc-listing',
   vertical_card: 'cc-card-listing'

--- a/src/components/Listing/Listing.tsx
+++ b/src/components/Listing/Listing.tsx
@@ -8,12 +8,18 @@ type ListingProps = {
   as?: 'div' | 'ol' | 'ul';
   children: JSX.Element | JSX.Element[];
   className?: string;
-  variant?: 'horizontal_card' | 'link_list' | 'text_list' | 'vertical_card';
+  variant?:
+    | 'image_card'
+    | 'horizontal_card'
+    | 'link_list'
+    | 'text_list'
+    | 'vertical_card';
 };
 
 // Specific style variations for card listings
 const variantMapping = {
   horizontal_card: 'cc-card-listing cc-card-listing--horizontal',
+  image_card: 'cc-card-listing',
   link_list: 'cc-listing',
   text_list: 'cc-listing',
   vertical_card: 'cc-card-listing'

--- a/src/components/Listing/Listing.tsx
+++ b/src/components/Listing/Listing.tsx
@@ -9,9 +9,11 @@ type ListingProps = {
   children: JSX.Element | JSX.Element[];
   className?: string;
   variant?:
-    | 'image_card'
     | 'horizontal_card'
+    | 'image_card'
+    | 'link_card_cta_link'
     | 'link_list'
+    | 'mid_page_card'
     | 'text_list'
     | 'vertical_card';
 };
@@ -20,7 +22,9 @@ type ListingProps = {
 const variantMapping = {
   horizontal_card: 'cc-card-listing cc-card-listing--horizontal',
   image_card: 'cc-card-listing cc-card-listing--horizontal',
+  link_card_cta_link: 'cc-card-listing cc-card-listing--horizontal',
   link_list: 'cc-listing',
+  mid_page_card: 'cc-card-listing',
   text_list: 'cc-listing',
   vertical_card: 'cc-card-listing'
 };

--- a/src/components/Listing/ListingElement/ListingElement.tsx
+++ b/src/components/Listing/ListingElement/ListingElement.tsx
@@ -9,6 +9,7 @@ import ResultsItem from 'ResultsItem/ResultsItem';
 type ListingElementProps = {
   authors?: string[];
   className?: string;
+  date?: string;
   description?: string;
   href: string;
   id?: string;
@@ -23,6 +24,7 @@ type ListingElementProps = {
     hasType?: boolean;
     type?: string | null;
   };
+  metaLabel?: string;
   title: string;
   fileMeta?: {
     type: string;
@@ -48,6 +50,7 @@ const variantElement = {
 export const ListingElement = ({
   authors,
   className,
+  date,
   description,
   href,
   fileMeta,
@@ -58,6 +61,7 @@ export const ListingElement = ({
   imageSrcSet,
   imageWidth,
   meta,
+  metaLabel,
   title,
   type,
   variant
@@ -75,7 +79,7 @@ export const ListingElement = ({
     <Element
       authors={authors}
       className={classNames}
-      date={meta.date}
+      date={date}
       description={description}
       fileMeta={fileMeta}
       href={href}
@@ -86,7 +90,7 @@ export const ListingElement = ({
       imageSrcSet={imageSrcSet}
       imageWidth={imageWidth}
       meta={meta}
-      metaLabel={meta.type}
+      metaLabel={metaLabel}
       title={title}
       type={type}
       variant={variant}

--- a/src/components/Listing/ListingElement/ListingElement.tsx
+++ b/src/components/Listing/ListingElement/ListingElement.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 
 import Card from 'Card';
+import ImageCard from 'ImageCard';
 import { ListingLink } from 'Listing/ListingLink/ListingLink';
 import ResultsItem from 'ResultsItem/ResultsItem';
 
@@ -32,11 +33,17 @@ type ListingElementProps = {
     size: string;
   };
   type?: 'content' | 'file' | 'taxonomy_term';
-  variant: 'horizontal_card' | 'link_list' | 'text_list' | 'vertical_card';
+  variant:
+    | 'image_card'
+    | 'horizontal_card'
+    | 'link_list'
+    | 'text_list'
+    | 'vertical_card';
 };
 
 const variantElement = {
   horizontal_card: Card,
+  image_card: ImageCard,
   link_list: ListingLink,
   text_list: ResultsItem,
   vertical_card: Card
@@ -68,14 +75,19 @@ export const ListingElement = ({
     <Element
       authors={authors}
       className={classNames}
+      date={meta.date}
       description={description}
       fileMeta={fileMeta}
       href={href}
       id={id}
       image={image}
+      imageAlt={image.alt}
+      imageSrc={image.src}
       meta={meta}
+      metaLabel={meta.type}
       title={title}
       type={type}
+      url={href}
       variant={variant}
     />
   );

--- a/src/components/Listing/ListingElement/ListingElement.tsx
+++ b/src/components/Listing/ListingElement/ListingElement.tsx
@@ -87,7 +87,6 @@ export const ListingElement = ({
       metaLabel={meta.type}
       title={title}
       type={type}
-      url={href}
       variant={variant}
     />
   );

--- a/src/components/Listing/ListingElement/ListingElement.tsx
+++ b/src/components/Listing/ListingElement/ListingElement.tsx
@@ -12,15 +12,11 @@ type ListingElementProps = {
   description?: string;
   href: string;
   id?: string;
-  image?: {
-    alt?: string;
-    src?: string;
-    // sources?: {
-    //   thumbnail_lo?: string;
-    //   thumbnail?: string;
-    //   thumbnail_hi?: string;
-    // };
-  };
+  imageAlt: string;
+  imageHeight?: string;
+  imageSrc: string;
+  imageSrcSet?: string;
+  imageWidth?: string;
   meta?: {
     date?: string;
     lastUpdated?: string;
@@ -56,7 +52,11 @@ export const ListingElement = ({
   href,
   fileMeta,
   id,
-  image,
+  imageAlt,
+  imageHeight,
+  imageSrc,
+  imageSrcSet,
+  imageWidth,
   meta,
   title,
   type,
@@ -80,9 +80,11 @@ export const ListingElement = ({
       fileMeta={fileMeta}
       href={href}
       id={id}
-      image={image}
-      imageAlt={image.alt}
-      imageSrc={image.src}
+      imageAlt={imageAlt}
+      imageHeight={imageHeight}
+      imageSrc={imageSrc}
+      imageSrcSet={imageSrcSet}
+      imageWidth={imageWidth}
       meta={meta}
       metaLabel={meta.type}
       title={title}

--- a/src/components/Listing/ListingElement/ListingElement.tsx
+++ b/src/components/Listing/ListingElement/ListingElement.tsx
@@ -34,7 +34,9 @@ type ListingElementProps = {
   variant:
     | 'image_card'
     | 'horizontal_card'
+    | 'link_card_cta_link'
     | 'link_list'
+    | 'mid_page_card'
     | 'text_list'
     | 'vertical_card';
 };
@@ -42,7 +44,15 @@ type ListingElementProps = {
 const variantElement = {
   horizontal_card: Card,
   image_card: ImageCard,
+
+  /**
+   * todo: Build + integrate Image card with CTA link component
+   *
+   * @see {@link https://github.com/wellcometrust/corporate/issues/7771}
+   */
+  link_card_cta_link: ImageCard,
   link_list: ListingLink,
+  mid_page_card: Card,
   text_list: ResultsItem,
   vertical_card: Card
 };
@@ -68,7 +78,8 @@ export const ListingElement = ({
 }: ListingElementProps) => {
   const classNames = cx({
     'cc-card--horizontal': variant === 'horizontal_card',
-    'cc-card--vertical': variant === 'vertical_card',
+    'cc-card--vertical':
+      variant === 'vertical_card' || variant === 'mid_page_card',
     [`${className}`]: className
   });
 


### PR DESCRIPTION
Allows `Listing` component to render `ImageCard` components. Part of https://github.com/wellcometrust/corporate/issues/7750

- adds ImageCard to Listing
- aligns props of ImageCard and Card components
- adds styles for displaying multiple sibling ImageCard components
- updates various type declarations: Card, ImageCard, ListingElement
- adds new ImageCard story (displays multiple ImageCard components)