### PR TITLE
#7773 feat: aligns prop names/types in FeaturedPromo and FullWidthPromo

### DIFF
--- a/src/components/FeaturedPromo/FeaturedPromo.stories.tsx
+++ b/src/components/FeaturedPromo/FeaturedPromo.stories.tsx
@@ -7,7 +7,7 @@ import { parseHtml } from 'utils/parse-html';
 import FeaturedPromo from './FeaturedPromo';
 
 const FeaturedPromoExample = () => {
-  const author = text('Author', 'Jeremy Farrar');
+  const authors = text('authors', 'Author One, Author Two');
 
   const imageAlt = text('Image alt text', 'Alternative image text');
   const imageSrc = text('Image path', `https://via.placeholder.com/300`);
@@ -20,26 +20,29 @@ const FeaturedPromoExample = () => {
     `<p>Nulla non Lorem in fugiat dolore aliquip ad irure reprehenderit reprehenderit proident.</p>`
   );
 
-  const topic = text('Topic', 'Climate Change');
+  const metaLabel = text('metaLabel', 'Climate Change');
 
-  const url = text('URL', '/news/all');
+  const href = text('href', '/news/all');
 
   return (
     <FeaturedPromo
-      author={author}
+      authors={authors
+        .trim()
+        .split(',')
+        .map(a => a.trim())}
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
       description={parseHtml(description)}
+      href={href}
       imageAlt={imageAlt}
       imageSrc={`${imageSrc}?text=${imageAlt}`}
+      metaLabel={metaLabel}
       title={title}
       titleAs={titleAs}
-      topic={topic}
-      url={url}
     />
   );
 };
 
-const stories = storiesOf('Components|FeaturedPromo', module);
+const stories = storiesOf('FeaturedPromo', module);
 
 stories.add('FeaturedPromo', FeaturedPromoExample);

--- a/src/components/FeaturedPromo/FeaturedPromo.tsx
+++ b/src/components/FeaturedPromo/FeaturedPromo.tsx
@@ -9,6 +9,7 @@ type FeaturedPromoProps = {
   authors?: string[];
   className?: string;
   description?: string;
+  href: string;
   imageAlt: string;
   imageHeight?: string;
   imageSizes?: string;
@@ -18,7 +19,6 @@ type FeaturedPromoProps = {
   metaLabel?: string;
   title: string;
   titleAs?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  href: string;
 };
 
 export const FeaturedPromo = ({

--- a/src/components/FeaturedPromo/FeaturedPromo.tsx
+++ b/src/components/FeaturedPromo/FeaturedPromo.tsx
@@ -6,7 +6,7 @@ import RichText from 'RichText';
 import Link from 'Link';
 
 type FeaturedPromoProps = {
-  author: string;
+  authors?: string[];
   className?: string;
   description?: string;
   imageAlt: string;
@@ -15,26 +15,25 @@ type FeaturedPromoProps = {
   imageSrc: string;
   imageSrcSet?: string;
   imageWidth?: string;
+  metaLabel?: string;
   title: string;
   titleAs?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  topic: string;
-  url: string;
+  href: string;
 };
 
 export const FeaturedPromo = ({
-  author,
+  authors,
   className,
   description,
+  href,
   imageAlt,
   imageHeight,
-  imageSizes,
   imageSrc,
   imageSrcSet,
   imageWidth,
+  metaLabel,
   title,
-  titleAs = 'h3',
-  topic,
-  url
+  titleAs = 'h3'
 }: FeaturedPromoProps) => {
   const TitleElement = titleAs;
   const classNames = cx('cc-featured-promo', {
@@ -47,13 +46,12 @@ export const FeaturedPromo = ({
       itemScope
       itemType="https://schema.org/Article"
     >
-      <Link className="cc-featured-promo__figure" to={url}>
+      <Link className="cc-featured-promo__figure" to={href}>
         <figure className="cc-featured-promo__image">
           <ImageElement
             alt={imageAlt}
             height={imageHeight}
             itemProp="image"
-            sizes={imageSizes}
             src={imageSrc}
             srcSet={imageSrcSet}
             width={imageWidth}
@@ -62,18 +60,28 @@ export const FeaturedPromo = ({
       </Link>
       <div className="cc-featured-promo__body">
         <span className="cc-featured-promo__meta">
-          <span className="cc-featured-promo__meta-item cc-featured-promo__meta-item--flag cc-featured-promo__meta-item--topic">
-            {topic}
-          </span>
-          <span
-            className="cc-featured-promo__meta-item cc-featured-promo__meta-item--author"
-            itemProp="author"
-          >
-            {author}
-          </span>
+          {metaLabel && (
+            <span className="cc-featured-promo__meta-item cc-featured-promo__meta-item--flag cc-featured-promo__meta-item--label">
+              {metaLabel}
+            </span>
+          )}
+          {authors?.length && (
+            <dl className="cc-featured-promo__meta-item cc-featured-promo__meta-item--author cc-featured-promo__authors">
+              <dt className="cc-featured-promo__authors-label">Author</dt>
+              {authors?.map(author => (
+                <dd
+                  key={author}
+                  className="cc-featured-promo__author"
+                  itemProp="author"
+                >
+                  {author}
+                </dd>
+              ))}
+            </dl>
+          )}
         </span>
         <TitleElement className="cc-featured-promo__title" itemProp="name">
-          <Link className="cc-featured-promo__link" to={url}>
+          <Link className="cc-featured-promo__link" to={href}>
             {title}
           </Link>
         </TitleElement>

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -50,8 +50,9 @@
 }
 
 .cc-featured-promo__meta {
-  display: block;
-  line-height: 1;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
   margin-bottom: calc(2 * var(--space-unit));
 
   @include mq(sm) {
@@ -67,21 +68,39 @@
   margin-right: var(--space-unit);
 }
 
-.cc-featured-promo__meta-item--topic {
+.cc-featured-promo__meta-item--label {
   color: var(--colour-grey-60);
   font-size: var(--body-xs);
   text-transform: uppercase;
-}
-
-.cc-featured-promo__meta-item--author {
-  font-size: var(--body-md);
 }
 
 .cc-featured-promo__meta-item--flag {
   &:after {
     color: var(--colour-amber-30);
     content: '/';
-    margin-left: var(--space-unit);
+    margin-left: var(--space-xs);
+  }
+}
+
+.cc-featured-promo__authors {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: var(--body-md);
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.cc-featured-promo__authors-label {
+  @extend %visually-hidden;
+}
+
+.cc-featured-promo__author {
+  margin-left: 0;
+
+  &:not(:last-child):after {
+    content: ', ';
+    white-space: pre;
   }
 }
 

--- a/src/components/FullWidthPromo/FullWidthPromo.tsx
+++ b/src/components/FullWidthPromo/FullWidthPromo.tsx
@@ -15,8 +15,7 @@ type FullWidthPromoProps = {
   imageCredit?: string;
   imageHeight?: string;
   imageLicence?: string;
-  imageSizes?: string;
-  imageSrc?: string;
+  imageSrc: string;
   imageSrcSet?: string;
   imageWidth?: string;
   linkText: string;
@@ -31,7 +30,6 @@ export const FullWidthPromo = ({
   href,
   imageAlt,
   imageHeight,
-  imageSizes,
   imageSrc,
   imageSrcSet,
   imageWidth,
@@ -45,19 +43,16 @@ export const FullWidthPromo = ({
     itemScope
     itemType="https://schema.org/Article"
   >
-    {(!!imageSrc || (imageSrcSet && imageSizes)) && (
-      <figure className="cc-full-width-promo__image">
-        <ImageElement
-          alt={imageAlt}
-          height={imageHeight}
-          itemProp="image"
-          sizes={imageSizes}
-          src={imageSrc}
-          srcSet={imageSrcSet}
-          width={imageWidth}
-        />
-      </figure>
-    )}
+    <figure className="cc-full-width-promo__image">
+      <ImageElement
+        alt={imageAlt}
+        height={imageHeight}
+        itemProp="image"
+        src={imageSrc}
+        srcSet={imageSrcSet}
+        width={imageWidth}
+      />
+    </figure>
     <div className="cc-full-width-promo__container grid">
       <div className="cc-full-width-promo__content">
         {(metaLabel || authors) && (
@@ -65,7 +60,7 @@ export const FullWidthPromo = ({
             {metaLabel && (
               <p className="cc-full-width-promo__type">{metaLabel}</p>
             )}
-            {authors && (
+            {authors?.length && (
               <dl className="cc-full-width-promo__authors">
                 <dt className="cc-full-width-promo__authors-label">Author</dt>
                 {authors?.map(author => (

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { Contact } from 'Contact/Contact';
 export { CookieMessage } from 'CookieMessage/CookieMessage';
 export { default as DateInput } from 'DateInput';
 export { Modal } from 'Modal/Modal';
+export { default as FeaturedPromo } from 'FeaturedPromo';
 export { FileDownload } from 'FileDownload/FileDownload';
 export { Footer } from 'Footer/Footer';
 export { FormattedDate } from 'FormattedDate/FormattedDate';


### PR DESCRIPTION
Aligns prop names + types across FeaturedPromo and FullWidthPromo components

See wellcometrust/corporate/issues/7773

- updates various prop names + types in FeaturedPromo
- updates DOM in FeaturedPromo (to allow for updated `authors` prop - is now an array)
- updates styles in FeaturedPromo (to align with above DOM)
- updates `imageSrcSet` prop to optional in FullWidthPromo
- updates `imageSrc` prop to required in FullWidthPromo
- updates FullWidthPromo storybook component