### PR TITLE
#7779 feat: sizes attribute card component

### DIFF
--- a/src/components/FeaturedPromo/FeaturedPromo.tsx
+++ b/src/components/FeaturedPromo/FeaturedPromo.tsx
@@ -52,6 +52,12 @@ export const FeaturedPromo = ({
             alt={imageAlt}
             height={imageHeight}
             itemProp="image"
+            sizes="
+              (min-width: 1500px) 672px,
+              (min-width: 1024px) 45vw,
+              (min-width: 768px) 37.5vw,
+              90vw
+            "
             src={imageSrc}
             srcSet={imageSrcSet}
             width={imageWidth}

--- a/src/components/FeaturedPromo/FeaturedPromo.tsx
+++ b/src/components/FeaturedPromo/FeaturedPromo.tsx
@@ -28,6 +28,7 @@ export const FeaturedPromo = ({
   href,
   imageAlt,
   imageHeight,
+  imageSizes = '(min-width: 1500px) 672px, (min-width: 1024px) 45vw, (min-width: 768px) 37.5vw, 90vw',
   imageSrc,
   imageSrcSet,
   imageWidth,
@@ -52,12 +53,7 @@ export const FeaturedPromo = ({
             alt={imageAlt}
             height={imageHeight}
             itemProp="image"
-            sizes="
-              (min-width: 1500px) 672px,
-              (min-width: 1024px) 45vw,
-              (min-width: 768px) 37.5vw,
-              90vw
-            "
+            sizes={imageSizes}
             src={imageSrc}
             srcSet={imageSrcSet}
             width={imageWidth}

--- a/src/components/FullWidthPromo/FullWidthPromo.tsx
+++ b/src/components/FullWidthPromo/FullWidthPromo.tsx
@@ -15,6 +15,7 @@ type FullWidthPromoProps = {
   imageCredit?: string;
   imageHeight?: string;
   imageLicence?: string;
+  imageSizes?: string;
   imageSrc: string;
   imageSrcSet?: string;
   imageWidth?: string;
@@ -30,6 +31,7 @@ export const FullWidthPromo = ({
   href,
   imageAlt,
   imageHeight,
+  imageSizes = '100vw',
   imageSrc,
   imageSrcSet,
   imageWidth,
@@ -48,7 +50,7 @@ export const FullWidthPromo = ({
         alt={imageAlt}
         height={imageHeight}
         itemProp="image"
-        sizes="100vw"
+        sizes={imageSizes}
         src={imageSrc}
         srcSet={imageSrcSet}
         width={imageWidth}

--- a/src/components/FullWidthPromo/FullWidthPromo.tsx
+++ b/src/components/FullWidthPromo/FullWidthPromo.tsx
@@ -48,6 +48,7 @@ export const FullWidthPromo = ({
         alt={imageAlt}
         height={imageHeight}
         itemProp="image"
+        sizes="100vw"
         src={imageSrc}
         srcSet={imageSrcSet}
         width={imageWidth}

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -52,6 +52,12 @@ export const ImageCard = ({
             alt={imageAlt}
             height={imageHeight}
             itemProp="image"
+            sizes="
+              (min-width: 1500px) 400px,
+              (min-width: 1024px) calc(30vw - 48px),
+              (min-width: 768px) calc(30vw - 40px),
+              90vw
+            "
             src={imageSrc}
             srcSet={imageSrcSet}
             width={imageWidth}

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -28,6 +28,7 @@ export const ImageCard = ({
   href,
   imageAlt,
   imageHeight,
+  imageSizes = '(min-width: 1500px) 400px, (min-width: 1024px) calc(30vw - 48px),    (min-width: 768px) calc(30vw - 40px), 90vw',
   imageSrc,
   imageSrcSet,
   imageWidth,
@@ -52,12 +53,7 @@ export const ImageCard = ({
             alt={imageAlt}
             height={imageHeight}
             itemProp="image"
-            sizes="
-              (min-width: 1500px) 400px,
-              (min-width: 1024px) calc(30vw - 48px),
-              (min-width: 768px) calc(30vw - 40px),
-              90vw
-            "
+            sizes={imageSizes}
             src={imageSrc}
             srcSet={imageSrcSet}
             width={imageWidth}

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -28,7 +28,7 @@ export const ImageCard = ({
   href,
   imageAlt,
   imageHeight,
-  imageSizes = '(min-width: 1500px) 400px, (min-width: 1024px) calc(30vw - 48px),    (min-width: 768px) calc(30vw - 40px), 90vw',
+  imageSizes = '(min-width: 1500px) 400px, (min-width: 1024px) calc(30vw - 48px), (min-width: 768px) calc(30vw - 40px), 90vw',
   imageSrc,
   imageSrcSet,
   imageWidth,


### PR DESCRIPTION
See wellcometrust/corporate/issues/7779

- adds `imageSizes` prop to FeaturedPromo, FullWidthPromo and ImageCard components
- sets defaults for `imageSizes` on each