### PR TITLE
#7795 feat: bg color featured promo image

### DIFF
--- a/src/assets/styles/20-tools/_extends/_images.scss
+++ b/src/assets/styles/20-tools/_extends/_images.scss
@@ -12,6 +12,7 @@
  */
 %img-responsive {
   > img {
+    background-color: var(--colour-amber-05);
     display: block;
     height: auto;
     width: 100%;
@@ -27,12 +28,14 @@
  */
 %img-cover {
   > img {
+    background-color: var(--colour-amber-05);
+    display: block;
+    width: 100%;
+
     @supports (object-fit: cover) {
-      display: block;
       height: 100%;
       object-fit: cover;
       object-position: center center;
-      width: 100%;
     }
   }
 }

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -33,8 +33,9 @@
 }
 
 .cc-featured-promo__image {
-  @extend %img-responsive;
+  @extend %img-cover;
 
+  height: 100%;
   margin: 0;
 }
 


### PR DESCRIPTION
See wellcometrust/corporate/issues/7795


- adds bg-color to all `%img-*` extends
- applies height + bg-color to featured promo image 