### PR TITLE
#7796 feat: sets linkText as optional in FullWidthPromo

### DIFF
--- a/src/components/FullWidthPromo/FullWidthPromo.tsx
+++ b/src/components/FullWidthPromo/FullWidthPromo.tsx
@@ -18,7 +18,7 @@ type FullWidthPromoProps = {
   imageSrc: string;
   imageSrcSet?: string;
   imageWidth?: string;
-  linkText: string;
+  linkText?: string;
   metaLabel?: string;
   title: string;
   topics: TagProps[];
@@ -89,15 +89,17 @@ export const FullWidthPromo = ({
             {description}
           </RichText>
         )}
-        <Button
-          className="cc-full-width-promo__link cc-cta-link"
-          href={href}
-          icon="arrowLong"
-          iconPlacementSwitch
-          variant="unstyled"
-        >
-          {linkText}
-        </Button>
+        {!!linkText?.trim().length && (
+          <Button
+            className="cc-full-width-promo__link cc-cta-link"
+            href={href}
+            icon="arrowLong"
+            iconPlacementSwitch
+            variant="unstyled"
+          >
+            {linkText}
+          </Button>
+        )}
         {topics && (
           <div className="cc-page-header-compact__topics">
             <TagList tags={topics} />


### PR DESCRIPTION
See https://github.com/wellcometrust/corporate/issues/7796

- sets `linkText` prop to optional
- conditionally renders DOM based on `linkText` presence