### PR TITLE
#7791 feat(style): adds border-top/bottom to PageHeaderCompact 'tray'

### DIFF
--- a/src/components/PageHeaderCompact/_page-header-compact.scss
+++ b/src/components/PageHeaderCompact/_page-header-compact.scss
@@ -122,19 +122,14 @@
 
 .cc-page-header-compact__tray {
   align-items: center;
+  border-bottom: 1px solid var(--colour-grey-05);
+  border-top: 1px solid var(--colour-grey-05);
   color: var(--colour-grey-60);
   display: flex;
   font-size: var(--body-md);
   justify-content: space-between;
-
-  @include mq(sm) {
-    padding-bottom: calc(2 * var(--space-unit));
-    /**
-     * Adds some extra distance between the tray and siblings, without
-     * wanting to confuse the generic spacing on .cc-page-header__section
-     */
-    padding-top: calc(2 * var(--space-unit));
-  }
+  padding-bottom: calc(2 * var(--space-unit));
+  padding-top: calc(2 * var(--space-unit));
 }
 
 /**


### PR DESCRIPTION
See https://github.com/wellcometrust/corporate/issues/7791

- adds border-top/bottom to PageHeaderCompact "tray"
- adds extra padding-top/bottom on mobile (aligns with Zeplin design https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/5f846d2074409385f0d88603)