### PR TITLE
#7652 feat: event action downloads

### DIFF
--- a/src/components/FileDownload/FileDownload.tsx
+++ b/src/components/FileDownload/FileDownload.tsx
@@ -3,15 +3,19 @@ import cx from 'classnames';
 
 type FileDownloadProps = {
   className?: string;
+  gaFileType?: string;
+  gaReportType?: string;
   href: string;
   label?: string;
   name?: string;
   size?: string;
-  type?: string;
+  type: string;
 };
 
 export const FileDownload = ({
   className,
+  gaFileType,
+  gaReportType,
   href,
   label = 'Download',
   name,
@@ -26,6 +30,9 @@ export const FileDownload = ({
     <div className={classNames}>
       <a
         className="cc-file-download__link"
+        // todo: #7814
+        data-file-type={gaFileType}
+        data-report-type={gaReportType}
         download
         href={href}
         rel="noopener noreferrer"

--- a/src/components/FileDownload/FileDownload.tsx
+++ b/src/components/FileDownload/FileDownload.tsx
@@ -3,8 +3,8 @@ import cx from 'classnames';
 
 type FileDownloadProps = {
   className?: string;
-  gaFileType?: string;
-  gaReportType?: string;
+  documentSubType?: string;
+  documentType?: string;
   href: string;
   label?: string;
   name?: string;
@@ -14,8 +14,8 @@ type FileDownloadProps = {
 
 export const FileDownload = ({
   className,
-  gaFileType,
-  gaReportType,
+  documentSubType,
+  documentType,
   href,
   label = 'Download',
   name,
@@ -31,8 +31,8 @@ export const FileDownload = ({
       <a
         className="cc-file-download__link"
         // todo: #7814
-        data-file-type={gaFileType}
-        data-report-type={gaReportType}
+        data-file-type={documentType}
+        data-report-type={documentSubType}
         download
         href={href}
         rel="noopener noreferrer"

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -7,6 +7,9 @@ type LinkProps = {
   className?: string;
   to: string;
   children: React.ReactNode;
+
+  // allows the Link to accept spread props (we should aim to remove this)
+  [key: string]: string | React.ReactNode;
 };
 
 /**

--- a/src/components/Listing/ListingLink/ListingLink.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.tsx
@@ -10,6 +10,8 @@ type ListingLinkProps = {
     type: string;
     size: string;
   };
+  gaFileType?: string;
+  gaReportType?: string;
   href: string;
   title: string;
   iconVariant?: 'chevron' | 'download';
@@ -18,6 +20,8 @@ type ListingLinkProps = {
 export const ListingLink = ({
   className,
   fileMeta,
+  gaFileType,
+  gaReportType,
   href,
   title,
   iconVariant = 'chevron'
@@ -32,7 +36,13 @@ export const ListingLink = ({
 
   return (
     <li className={classNames}>
-      <Link className="cc-listing__link" to={href}>
+      <Link
+        className="cc-listing__link"
+        // todo: #7814
+        data-file-type={gaFileType}
+        data-report-type={gaReportType}
+        to={href}
+      >
         {title}
         {fileMeta?.type && fileMeta?.size && (
           <>

--- a/src/components/Listing/ListingLink/ListingLink.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.tsx
@@ -10,8 +10,8 @@ type ListingLinkProps = {
     type: string;
     size: string;
   };
-  gaFileType?: string;
-  gaReportType?: string;
+  documentSubType?: string;
+  documentType?: string;
   href: string;
   title: string;
   iconVariant?: 'chevron' | 'download';
@@ -20,8 +20,8 @@ type ListingLinkProps = {
 export const ListingLink = ({
   className,
   fileMeta,
-  gaFileType,
-  gaReportType,
+  documentSubType,
+  documentType,
   href,
   title,
   iconVariant = 'chevron'
@@ -39,8 +39,8 @@ export const ListingLink = ({
       <Link
         className="cc-listing__link"
         // todo: #7814
-        data-file-type={gaFileType}
-        data-report-type={gaReportType}
+        data-file-type={documentType}
+        data-report-type={documentSubType}
         to={href}
       >
         {title}

--- a/src/components/ResultsItem/ResultsItem.tsx
+++ b/src/components/ResultsItem/ResultsItem.tsx
@@ -11,8 +11,8 @@ type ResultItemProps = {
   children?: React.ReactNode;
   className?: string;
   description?: string;
-  gaFileType?: string;
-  gaReportType?: string;
+  documentSubType?: string;
+  documentType?: string;
   href: string;
   id?: string;
   meta?: {
@@ -33,8 +33,8 @@ export const ResultsItem = ({
   children,
   className,
   description,
-  gaFileType,
-  gaReportType,
+  documentSubType,
+  documentType,
   fileMeta,
   href,
   id,
@@ -93,9 +93,8 @@ export const ResultsItem = ({
       {type === 'file' && (
         <FileDownload
           className="cc-result-item__file-meta"
-          // todo: #7814
-          gaFileType={gaFileType}
-          gaReportType={gaReportType}
+          documentType={documentType}
+          documentSubType={documentSubType}
           href={href}
           name={title}
           size={fileMeta.size}

--- a/src/components/ResultsItem/ResultsItem.tsx
+++ b/src/components/ResultsItem/ResultsItem.tsx
@@ -11,6 +11,8 @@ type ResultItemProps = {
   children?: React.ReactNode;
   className?: string;
   description?: string;
+  gaFileType?: string;
+  gaReportType?: string;
   href: string;
   id?: string;
   meta?: {
@@ -31,6 +33,8 @@ export const ResultsItem = ({
   children,
   className,
   description,
+  gaFileType,
+  gaReportType,
   fileMeta,
   href,
   id,
@@ -89,6 +93,9 @@ export const ResultsItem = ({
       {type === 'file' && (
         <FileDownload
           className="cc-result-item__file-meta"
+          // todo: #7814
+          gaFileType={gaFileType}
+          gaReportType={gaReportType}
           href={href}
           name={title}
           size={fileMeta.size}


### PR DESCRIPTION
In order for analytics events to fire on file download links in the same manner as on D7, we need to add some `data-*` attributes to the `<a>` tag. Allows corporate-react to pass props a la https://github.com/wellcometrust/corporate-react/pull/620.

See wellcometrust/corporate/issues/7652

- adds `documentType`, `documentSubType` props to:
  - `<ListingLink />`
  - `<ResultItem />`
  - `<FileDownload />`
- delcares spread props on `Link` component's type