### PR TITLE
#7839 feat: prepends 'Credit: ' to PageHeaderCompact imageCredit text

### DIFF
--- a/src/components/PageHeaderCompact/PageHeaderCompact.tsx
+++ b/src/components/PageHeaderCompact/PageHeaderCompact.tsx
@@ -62,7 +62,9 @@ export const PageHeaderCompact = ({
             </RichText>
           )}
           {imageCredit && (
-            <RichText className="cc-media__credit">{imageCredit}</RichText>
+            <RichText className="cc-media__credit">
+              {`Credit: ${imageCredit}`}
+            </RichText>
           )}
           {imageLicence && (
             <RichText className="cc-media__license">{imageLicence}</RichText>


### PR DESCRIPTION
See wellcometrust/corporate/issues/7839 & https://github.com/wellcometrust/corporate/issues/7790

- prepends `Credit: ` text in PageHeaderCompact