### PR TITLE
#7780 feat: implement responsive Iframe component

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -37,6 +37,7 @@
 @import './src/components/FormFieldHint/form-field-hint';
 @import './src/components/FormSelect/form-select';
 @import './src/components/FullWidthPromo/full-width-promo';
+@import './src/components/Iframe/iframe';
 @import './src/components/ImageBanner/image-banner';
 @import './src/components/InfoBox/info-box';
 @import './src/components/InpageNav/inpage-nav';

--- a/src/components/Iframe/Iframe.test.tsx
+++ b/src/components/Iframe/Iframe.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Iframe from './Iframe';
+
+describe('<Iframe />', () => {
+  const output = shallow(
+    <Iframe
+      src="https://www.example.com"
+      width={640}
+      height={480}
+      title="An example"
+    />
+  );
+
+  it('renders the component', () => {
+    expect(output);
+  });
+
+  it('sets container padding-top to aspect ratio', () => {
+    const { paddingTop } = output.props().style;
+    expect(paddingTop).toEqual('75.00%');
+  });
+
+  it('does not specify iframe element width/height', () => {
+    const iframeProps = output.find('iframe').props();
+    expect('width' in iframeProps).toBeFalsy();
+    expect('height' in iframeProps).toBeFalsy();
+  });
+
+  it('sets iframe src and title', () => {
+    const iframeProps = output.find('iframe').props();
+    expect(iframeProps.title).toEqual('An example');
+    expect(iframeProps.src).toEqual('https://www.example.com');
+  });
+});

--- a/src/components/Iframe/Iframe.tsx
+++ b/src/components/Iframe/Iframe.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export type IframeProps = {
+  src: string;
+  width: number;
+  height: number;
+  title: string;
+};
+
+export const Iframe = ({ src, width, height, title }: IframeProps) => (
+  // Make this responsive by ignoring width/height, but using a container div with paddingTop
+  // to ensure aspect ratio is respected.
+  <div
+    className="cc-iframe"
+    style={{ paddingTop: `${((100 * height) / width).toFixed(2)}%` }}
+  >
+    <iframe className="cc-iframe__iframe" src={src} title={title} />
+  </div>
+);
+
+export default Iframe;

--- a/src/components/Iframe/_iframe.scss
+++ b/src/components/Iframe/_iframe.scss
@@ -1,0 +1,22 @@
+// ----------------------------------
+// UI Components
+// ImageBanner
+// ----------------------------------
+// Design System 1.0 Alpha
+// 2019-11-11
+// ----------------------------------
+
+.cc-iframe {
+  overflow: hidden;
+  position: relative;
+}
+
+.cc-iframe__iframe {
+  border: 0;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  scroll-behavior: auto;
+  top: 0;
+  width: 100%;
+}

--- a/src/components/Iframe/index.ts
+++ b/src/components/Iframe/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Iframe';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export { Grid, GridCell } from 'Grid/Grid';
 export { Hamburger } from 'Hamburger/Hamburger';
 export { Header } from 'Header/Header';
 export { Icon } from 'Icon/Icon';
+export { default as Iframe } from 'Iframe';
 export { Image } from 'Image/Image';
 export { ImageBanner } from 'ImageBanner/ImageBanner';
 export { InfoBox } from 'InfoBox/InfoBox';


### PR DESCRIPTION
The Iframe component is made responsive with a fairly well documented technique (add a wrapper div, add padding-top to set aspect ratio, and make iframe absolutly positioned within it). Tested with Google Maps (only current use case) on FF and Chrome on Mac. Not tested with Edge yet.

Note that while the component is provided with width/height, it does not enforce the values - it uses them to calculate the aspect ratio. I felt it was best to leave the decision (use exact width/height or just aspect ratio) as far down the stack as possible - so the FE component has full control.

The Iframe Embed paragrah in D8 asks for width/height because that's what iframe embed snippets always contain, but the help text does inform users that only the aspect ratio is guaranteed, not the exact size.