### PR TITLE
#7889 feat: update currentCount type in ResultsCount

### DIFF
--- a/src/components/ResultsCount/ResultsCount.tsx
+++ b/src/components/ResultsCount/ResultsCount.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 
 type ResultsCountProps = {
   className?: string;
-  currentCount: number;
+  currentCount: string;
   resultsCount: number;
   sortedBy: string;
 };


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7889

after updating the results message to `Showing 21-40 of 3000` we need to update the `currentCount` type (related PR in CR: https://github.com/wellcometrust/corporate-react/pull/659)