### PR TITLE
#7823 Make Contact component handle multiple institutions

### DIFF
--- a/src/components/Contact/Contact.test.tsx
+++ b/src/components/Contact/Contact.test.tsx
@@ -7,7 +7,9 @@ describe('<Contact />', () => {
   const output = shallow(
     <Contact
       email="s.pritchard@wellcome.org"
-      institution="Stuart's Institute"
+      institutions={[
+        { name: "Stuart's Institute", country: ' United Kingdom' }
+      ]}
       name="Stuart Pritchard"
       contactRole="<p>EU and Public Affairs Manager</p>"
       tel=""

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -11,6 +11,11 @@ type ContactImageSourceProps = {
   image_full_mobile_hi?: string;
 };
 
+type InstitutionProps = {
+  name?: string;
+  country?: string;
+};
+
 type ContactProps = {
   className?: string;
   contactFormLink?: {
@@ -19,8 +24,7 @@ type ContactProps = {
   };
   email?: string;
   imageSources?: ContactImageSourceProps;
-  institution?: string;
-  institutionCountry?: string;
+  institutions?: InstitutionProps[];
   contactRole?: string;
   name?: string;
   teamTitle?: string;
@@ -33,8 +37,7 @@ export const Contact = ({
   contactFormLink,
   email,
   imageSources,
-  institution,
-  institutionCountry,
+  institutions,
   contactRole,
   name,
   teamTitle,
@@ -67,13 +70,12 @@ export const Contact = ({
           {contactRole}
         </RichText>
       )}
-      {institution && (
-        <p className="cc-contact__institution" itemProp="worksFor">
-          {institutionCountry
-            ? `${institution}, ${institutionCountry}`
-            : institution}
-        </p>
-      )}
+      {institutions &&
+        institutions.map(e => (
+          <p className="cc-contact__institution" itemProp="worksFor">
+            {e.country ? `${e.name}, ${e.country}` : e.name}
+          </p>
+        ))}
       {teamUrl && (
         <p className="cc-contact__item">
           <Icon name="shareLink" className="cc-contact__link-icon" />

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -71,9 +71,9 @@ export const Contact = ({
         </RichText>
       )}
       {institutions &&
-        institutions.map(e => (
+        institutions.map(({ country, name: institutionName }) => (
           <p className="cc-contact__institution" itemProp="worksFor">
-            {e.country ? `${e.name}, ${e.country}` : e.name}
+            {country ? `${institutionName}, ${country}` : institutionName}
           </p>
         ))}
       {teamUrl && (


### PR DESCRIPTION
It is now possible to select multiple institutions for a contact in the Drupal backend.

This PR updates the Contact component to accept an array of institutions, rather than a single one.

Note I didn't feel it worthwhile to create an &lt;Institution&gt; component, as this is the only place this is used (and likely if it was used elsewhere, it would be displayed differently).

Matching changes to corporate-react are done and will come once this is merged & published.