### PR TITLE
#7935 feat: allow TextCard to accept titleAs prop

### DIFF
--- a/src/components/TextCard/TextCard.tsx
+++ b/src/components/TextCard/TextCard.tsx
@@ -22,6 +22,7 @@ type TextCardProps = {
   id?: string;
   metaLabel?: string;
   title: string;
+  titleAs?: 'h2' | 'h3';
   type?: 'content' | 'file' | 'taxonomy_term';
 };
 
@@ -40,8 +41,10 @@ export const TextCard = ({
   id,
   metaLabel,
   title,
+  titleAs = 'h3',
   type
 }: TextCardProps) => {
+  const Element = titleAs;
   const classNames = cx('cc-text-card', {
     [`${className}`]: className
   });
@@ -81,7 +84,7 @@ export const TextCard = ({
           )}
         </div>
       )}
-      <h3 className="cc-text-card__title">
+      <Element className="cc-text-card__title">
         {type === 'file' ? (
           parseHtml(title)
         ) : (
@@ -89,7 +92,7 @@ export const TextCard = ({
             {parseHtml(title)}
           </a>
         )}
-      </h3>
+      </Element>
       {type === 'file' && (
         <FileDownload
           className="cc-text-card__file-meta"

--- a/src/components/TextCard/TextCard.tsx
+++ b/src/components/TextCard/TextCard.tsx
@@ -44,7 +44,7 @@ export const TextCard = ({
   titleAs = 'h3',
   type
 }: TextCardProps) => {
-  const Element = titleAs;
+  const TitleElement = titleAs;
   const classNames = cx('cc-text-card', {
     [`${className}`]: className
   });
@@ -84,7 +84,7 @@ export const TextCard = ({
           )}
         </div>
       )}
-      <Element className="cc-text-card__title">
+      <TitleElement className="cc-text-card__title">
         {type === 'file' ? (
           parseHtml(title)
         ) : (
@@ -92,7 +92,7 @@ export const TextCard = ({
             {parseHtml(title)}
           </a>
         )}
-      </Element>
+      </TitleElement>
       {type === 'file' && (
         <FileDownload
           className="cc-text-card__file-meta"


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7935

- add `titleAs` prop to the TextCard component