### PR TITLE
#7938 feature: adds status label to Timeline

### DIFF
--- a/src/components/Timeline/Timeline.stories.tsx
+++ b/src/components/Timeline/Timeline.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text } from '@storybook/addon-knobs';
+import { date, text } from '@storybook/addon-knobs';
+import { formatISO } from 'date-fns';
 
 import Timeline from './Timeline';
 import Readme from './Timeline.md';
@@ -12,11 +13,17 @@ const TimelineExample = () => {
   const milestone3ID = 'Milestone 3';
 
   const title = text('title', 'Beatles Albums', generalID);
+  const statusLabel = text(
+    'status label',
+    'Open to new submissions',
+    generalID
+  );
 
   const milestones = [
     {
       body: text('Milestone 1 body', 'This is the body text', milestone1ID),
-      date: text('Milestone 1 date', '1964', milestone1ID),
+      date: formatISO(date('Milestone 1 date', new Date(), milestone1ID)),
+      dateLabel: text('Milestone 1 date label', '1964', milestone1ID),
       linkHref: text(
         'Milestone 1 link href',
         '/beatles-for-sale',
@@ -27,33 +34,44 @@ const TimelineExample = () => {
         'Read more about Beatles for Sale',
         milestone1ID
       ),
+      statusLabel: text('Milestone 1 status label', null, milestone1ID),
       title: text('Milestone 1 title', 'Beatles for Sale', milestone1ID)
     },
     {
       body: text('Milestone 2 body', 'This is the body text', milestone2ID),
-      date: text('Milestone 2 date', '1965', milestone2ID),
+      date: formatISO(date('Milestone 2 date', new Date(), milestone2ID)),
+      dateLabel: text('Milestone 2 date', '1965', milestone2ID),
       linkHref: text('Milestone 2 link href', '/help', milestone2ID),
       linkText: text(
         'Milestone 2 link text',
         'Read more about Help',
         milestone2ID
       ),
+      statusLabel: text('Milestone 2 status label', null, milestone2ID),
       title: text('Milestone 2 title', 'Help', milestone2ID)
     },
     {
       body: text('Milestone 3 body', 'This is the body text', milestone3ID),
-      date: text('Milestone 3 date', '1965', milestone3ID),
+      date: formatISO(date('Milestone 3 date', new Date(), milestone3ID)),
+      dateLabel: text('Milestone 3 date', '1965', milestone3ID),
       linkHref: text('Milestone 3 link href', '/rubber-soul', milestone3ID),
       linkText: text(
         'Milestone 3 link text',
         'Read more about Rubber Soul',
         milestone3ID
       ),
+      statusLabel: text('Milestone 3 status label', null, milestone3ID),
       title: text('Milestone 3 title', 'Rubber Soul', milestone3ID)
     }
   ];
 
-  return <Timeline milestones={milestones} title={title} />;
+  return (
+    <Timeline
+      initialStatusLabel={statusLabel}
+      milestones={milestones}
+      title={title}
+    />
+  );
 };
 
 const stories = storiesOf('Components|Timeline', module);

--- a/src/components/Timeline/Timeline.test.tsx
+++ b/src/components/Timeline/Timeline.test.tsx
@@ -6,16 +6,19 @@ import Timeline from './Timeline';
 describe('<Timeline />', () => {
   const milestones = [
     {
-      date: '1964',
+      date: '1964-01-01T00:00:00Z',
+      dateLabel: '1964',
       title: 'Beatles for Sale'
     },
     {
       body: '<p>This is the body text</p>',
-      date: '1965',
+      date: '1965-01-01T00:00:00Z',
+      dateLabel: '1965',
       title: 'Help'
     },
     {
-      date: '1965',
+      date: '1965-01-01T00:00:00Z',
+      dateLabel: '1965',
       title: 'Rubber Soul'
     }
   ];

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -1,19 +1,23 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
+import { isPast, parseISO } from 'date-fns';
 
 import RichText from 'RichText';
 
 type TimelineMilestoneProps = {
   body?: string;
   date: string;
+  dateLabel: string;
   linkHref?: string;
   linkText?: string;
+  statusLabel?: string;
   title: string;
 };
 
 type TimelineProps = {
   className?: string;
   description?: string;
+  initialStatusLabel?: string;
   milestones: TimelineMilestoneProps[];
   title?: string;
 };
@@ -21,12 +25,61 @@ type TimelineProps = {
 export const Timeline = ({
   className,
   description,
+  initialStatusLabel,
   milestones,
   title
 }: TimelineProps) => {
   const classNames = cx('cc-timeline', {
     [className]: className
   });
+  const [statusLabel, setStatusLabel] = useState(initialStatusLabel);
+
+  /**
+   * In order to display the most up-to-date information in the browser
+   * we must filter our array of `milestones` to find the:
+   *
+   * - most recent milestone (milestone.date)
+   * - which has a statusLabel (milestone.statusLabel)
+   *
+   * @returns {string} statusLabel
+   */
+  const getCurrentStatusLabel = () => {
+    const currentMilestone = milestones
+      .filter(
+        milestone =>
+          milestone.statusLabel &&
+          // check the date value is a valid Date
+          typeof parseISO(milestone.date).getTime === 'function'
+      )
+      // convert date string to Date object (for Array.sort)
+      .map(milestone => ({
+        ...milestone,
+        date: parseISO(milestone.date)
+      }))
+      // use getTime b/c Typescript
+      .sort((a, b) => a.date.getTime() - b.date.getTime())
+      /**
+       * Returns first item in array which has a date in the past
+       * with optional chaining to return statusLabel if present.
+       */
+      .find(milestone => isPast(milestone.date));
+    return currentMilestone?.statusLabel ?? null;
+  };
+
+  /**
+   * We must run getCurrentStatusLabel() on the client (rather than
+   * passing the relevant data at build time) because the value is
+   * date/time-sensitive.
+   *
+   * This method should avoid discrepencies in the value when the
+   * component is statically rendered.
+   */
+  useEffect(() => {
+    setStatusLabel(prevStatusLabel => {
+      const newStatusLabel = getCurrentStatusLabel();
+      return newStatusLabel || initialStatusLabel;
+    });
+  }, [milestones]);
 
   return (
     <div className={classNames}>
@@ -34,31 +87,34 @@ export const Timeline = ({
       {description && (
         <RichText className="cc-timeline__description">{description}</RichText>
       )}
-      <ol className="cc-timeline__list">
-        {milestones.map((item, index) => (
-          <li
-            // index used to ensure no two <dt><dd> combos have identical keys
-            // eslint-disable-next-line react/no-array-index-key
-            key={`${index}-${item.date}-${item.title}`}
-            className="cc-timeline__item"
-          >
-            <div className="cc-timeline__item-date">{item.date}</div>
-            {item.linkHref && item.linkText && (
-              <a className="cc-timeline__item-link" href={item.linkHref}>
-                {item.linkText}
-              </a>
-            )}
-            <div className="cc-timeline__item-details">
-              <h4 className="cc-timeline__item-title">{item.title}</h4>
-              {item.body && (
-                <RichText className="cc-timeline__item-body">
-                  {item.body}
-                </RichText>
+      <div className="cc-timeline__main">
+        {statusLabel && <p className="cc-timeline__status">{statusLabel}</p>}
+        <ol className="cc-timeline__list">
+          {milestones.map((item, index) => (
+            <li
+              // index used to ensure no two <dt><dd> combos have identical keys
+              // eslint-disable-next-line react/no-array-index-key
+              key={`${index}-${item.date}-${item.title}`}
+              className="cc-timeline__item"
+            >
+              <div className="cc-timeline__item-date">{item.date}</div>
+              {item.linkHref && item.linkText && (
+                <a className="cc-timeline__item-link" href={item.linkHref}>
+                  {item.linkText}
+                </a>
               )}
-            </div>
-          </li>
-        ))}
-      </ol>
+              <div className="cc-timeline__item-details">
+                <h4 className="cc-timeline__item-title">{item.title}</h4>
+                {item.body && (
+                  <RichText className="cc-timeline__item-body">
+                    {item.body}
+                  </RichText>
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
     </div>
   );
 };

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -56,13 +56,16 @@ export const Timeline = ({
         ...milestone,
         date: parseISO(milestone.date)
       }))
+      // Filter for dates in the past
+      .filter(milestone => isPast(milestone.date))
       // use getTime b/c Typescript
-      .sort((a, b) => a.date.getTime() - b.date.getTime())
+      .sort((a, b) => b.date.getTime() - a.date.getTime())
       /**
        * Returns first item in array which has a date in the past
        * with optional chaining to return statusLabel if present.
        */
       .find(milestone => isPast(milestone.date));
+
     return currentMilestone?.statusLabel ?? null;
   };
 

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -1,12 +1,23 @@
+/**
+ * @file The Timeline component renders a piece of UI which is used
+ * to visually display a list of events in (usally) chronological
+ * order, e.g. applications process, historical events etc.
+ *
+ * Our Timeline component also calculates a "current status" which
+ * renders a specific piece of UI within the Timeline component
+ * displaying to users which of the `milestones` are currently active:
+ * "Where we currently are in the timeline of events".
+ */
+
 import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
-import { isPast, parseISO } from 'date-fns';
+import { isPast } from 'date-fns';
 
 import RichText from 'RichText';
 
 type TimelineMilestoneProps = {
   body?: string;
-  date: string;
+  date: string; // UTC date strings
   dateLabel: string;
   linkHref?: string;
   linkText?: string;
@@ -22,6 +33,23 @@ type TimelineProps = {
   title?: string;
 };
 
+/**
+ * Timeline component
+ *
+ * @param {string} className
+ * @param {string} description
+ * @param {string} initialStatusLabel
+ * @param {object[]} milestones[]
+ * @param {string} milestones[].body
+ * @param {string} milestones[].date UTC formatted date string
+ * @param {string} milestones[].dateLabel Human-readable date
+ * @param {string} milestones[].linkHref
+ * @param {string} milestones[].linkText
+ * @param {string} milestones[].statusLabel String describing status of the Timeline when this milestone is the most recent
+ * @param {string} milestones[].title
+ * @param {string} title
+ *
+ */
 export const Timeline = ({
   className,
   description,
@@ -50,13 +78,13 @@ export const Timeline = ({
       .filter(
         milestone =>
           milestone.statusLabel &&
-          typeof parseISO(milestone.date).getTime === 'function'
+          typeof new Date(milestone.date).getTime === 'function'
       )
 
       // convert date string to Date object (for Array.sort)
       .map(milestone => ({
         ...milestone,
-        date: parseISO(milestone.date)
+        date: new Date(milestone.date)
       }))
 
       // Filter for dates in the past

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -41,29 +41,31 @@ export const Timeline = ({
    * - most recent milestone (milestone.date)
    * - which has a statusLabel (milestone.statusLabel)
    *
-   * @returns {string} statusLabel
+   * @returns {string}
    */
   const getCurrentStatusLabel = () => {
     const currentMilestone = milestones
+
+      // check the date value is a valid Date
       .filter(
         milestone =>
           milestone.statusLabel &&
-          // check the date value is a valid Date
           typeof parseISO(milestone.date).getTime === 'function'
       )
+
       // convert date string to Date object (for Array.sort)
       .map(milestone => ({
         ...milestone,
         date: parseISO(milestone.date)
       }))
+
       // Filter for dates in the past
       .filter(milestone => isPast(milestone.date))
-      // use getTime b/c Typescript
+
+      // sort descending by date (most recent first), use getTime b/c Typescript
       .sort((a, b) => b.date.getTime() - a.date.getTime())
-      /**
-       * Returns first item in array which has a date in the past
-       * with optional chaining to return statusLabel if present.
-       */
+
+      // Find first match which is in the past
       .find(milestone => isPast(milestone.date));
 
     return currentMilestone?.statusLabel ?? null;

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -97,7 +97,7 @@ export const Timeline = ({
               key={`${index}-${item.date}-${item.title}`}
               className="cc-timeline__item"
             >
-              <div className="cc-timeline__item-date">{item.date}</div>
+              <div className="cc-timeline__item-date">{item.dateLabel}</div>
               {item.linkHref && item.linkText && (
                 <a className="cc-timeline__item-link" href={item.linkHref}>
                   {item.linkText}

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -84,7 +84,7 @@ export const Timeline = ({
       const newStatusLabel = getCurrentStatusLabel();
       return newStatusLabel || initialStatusLabel;
     });
-  }, [milestones]);
+  }, []);
 
   return (
     <div className={classNames}>

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -75,7 +75,7 @@ export const Timeline = ({
    * component is statically rendered.
    */
   useEffect(() => {
-    setStatusLabel(prevStatusLabel => {
+    setStatusLabel(() => {
       const newStatusLabel = getCurrentStatusLabel();
       return newStatusLabel || initialStatusLabel;
     });

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -36,6 +36,8 @@ type TimelineProps = {
 /**
  * Timeline component
  *
+ * @constructor
+ *
  * @param {string} className
  * @param {string} description
  * @param {string} initialStatusLabel

--- a/src/components/Timeline/_timeline.scss
+++ b/src/components/Timeline/_timeline.scss
@@ -20,9 +20,26 @@
   margin-bottom: var(--space-lg);
 }
 
-.cc-timeline__list {
+.cc-timeline__main {
   border-bottom: 1px solid var(--colour-grey-10);
   border-top: 1px solid var(--colour-grey-10);
+}
+
+.cc-timeline__status {
+  background-color: var(--colour-cyan-05);
+  float: right;
+  font-size: var(--body-md);
+  font-weight: bold;
+  line-height: 2.14;
+  padding-bottom: calc(0.5 * var(--space-unit));
+  padding-left: calc(2 * var(--space-unit));
+  padding-right: calc(2 * var(--space-unit));
+  padding-top: calc(0.5 * var(--space-unit));
+  text-transform: uppercase;
+}
+
+.cc-timeline__list {
+  clear: both;
   list-style: none;
   margin: 0;
   padding: calc(4 * var(--space-unit)) 0;


### PR DESCRIPTION
As per [the latest Funding Scheme page type prototype](https://www.figma.com/file/6x8YZi2UaQ9eRaXnWUy6Iq/Scheme-Page-Design-%26-Prototype), the Timeline component should display a "status label" indicating to users the current state of an application process for a Funding Scheme.

The status label displayed should reflect where the current date sits in the Timeline milestones, therefore it should be calculated on the client to avoid displaying an "outdated" date due to the users viewing a "stale" static render of a page.

See https://github.com/wellcometrust/corporate/issues/7938 for full context.

See also https://github.com/wellcometrust/corporate-react/pull/707 (sibling PR for corporate-react).

## This PR:

- adds `initialStatusLabel` prop to Timeline component
- adds function to Timeline component to calculate most recent milestone's status label (if present)
- updates Timeline.test.tsx to work with updated Component
- updates Timeline.stories.tsx to work with updated Component

## To test:

- check out `https://github.com/wellcometrust/corporate-react/tree/feature/timeline-status-label-%237938`
- `npm link` corporate-components in your local corporate-react
- add `NEXT_PUBLIC_API_DOMAIN=https://wt-corporated8-develop.codeenigma.net` to corporate-react .env
- `npm run dev` in corporate-react
- navigate to https://localhost:3001/what-we-do/our-work/timeline-status-label

## Notes:

The API (corporate-d8) has been updated to return:

- `timeline_status` (string) on the `paragraph--timeline_milestone` include
- `timeline_status` (string) on the `paragraph--timeline` include

You can see the API for an example node [here](https://wt-corporated8-develop.codeenigma.net/api/node/standard/8b370510-0fe2-4dbf-b12e-42a9fe2e9a22?include=sections_ref.content_slices_ref.accordion_slice_ref,sections_ref.content_slices_ref.content_slices_ref.accordion_slice_ref,banner_image_ref.field_image,sections_ref.content_slices_ref.content_slices_ref.institution.parent,sections_ref.content_slices_ref.library_item_ref.paragraphs.content_slices_ref,sections_ref.buttons_ref,sections_ref.content_slices_ref.image_ref.field_image,sections_ref.content_slices_ref.gallery_image_ref.field_image,sections_ref.content_slices_ref.content_slices_ref.linked_file.field_media_file,sections_ref.content_slices_ref.content_slices_ref.linked_file.media_type,sections_ref.content_slices_ref.content_slices_ref.linked_content.listing_image_ref.field_image,sections_ref.content_slices_ref.exclude_from_listing,listing_image_ref.field_image,sections_ref.content_slices_ref.content_slices_ref.content_slices_ref,sections_ref.content_slices_ref.content_slices_ref.image_ref.field_image,sections_ref.content_slices_ref.content_slices_ref.content_slices_ref.linked_content,sections_ref.content_slices_ref.content_slices_ref.content_slices_ref.linked_file.field_media_file,sections_ref.content_slices_ref,sections_ref.library_item_ref.paragraphs.content_slices_ref.content_slices_ref.content_slices_ref,sibling_navigation_ref,sections_ref.content_slices_ref.associated_file,sections_ref.content_slices_ref.timeline_slices_ref,sections_ref.content_slices_ref.video_embed_ref).