### PR TITLE
#7954 feat: update styles for find grants awarded page

### DIFF
--- a/src/assets/styles/10-settings/_colours.scss
+++ b/src/assets/styles/10-settings/_colours.scss
@@ -10,7 +10,6 @@
   --colour-black: #000;
   --colour-white: #fff;
 
-  --colour-amber-05: #fffbf0;
   --colour-amber-30: #fec200;
   --colour-amber-05: #fffbf0;
 

--- a/src/components/PageHeader/_page-header.scss
+++ b/src/components/PageHeader/_page-header.scss
@@ -62,6 +62,7 @@
 .cc-page-header__standfirst {
   font-size: var(--heading-md);
   margin-bottom: var(--space-xl);
+  text-align: center;
 
   > p {
     @extend %body-large;

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -29,6 +29,10 @@
   text-align: center;
 }
 
+.cc-pagination__break .cc-pagination__break-link { // overwrites a:not([href])
+  color: var(--colour-blue-60);
+}
+
 .cc-pagination__break-link,
 .cc-pagination__next-link,
 .cc-pagination__prev-link,
@@ -36,12 +40,15 @@
   align-items: center;
   cursor: pointer;
   display: flex;
+  font-size: var(--body-md);
   padding: var(--space-unit);
+  text-decoration: none;
 }
 
 .cc-pagination__next,
 .cc-pagination__prev {
-  font-weight: bold;
+  border: 1px solid var(--colour-grey-20);
+  border-radius: 2px;
 
   @include mq($until: xs) {
     width: 50%;
@@ -50,11 +57,11 @@
 
 .cc-pagination__next-link {
   justify-content: flex-end;
-  padding-right: 0;
+  padding-left: calc(1.5 * var(--space-unit));
 }
 
 .cc-pagination__prev-link {
-  padding-left: 0;
+  padding-right: calc(1.5 * var(--space-unit));
 
   // fix required to ensure non-breaking space used in IE11 fix
   // does not increase space between icon and text
@@ -65,7 +72,7 @@
 
 .cc-pagination__prev-icon,
 .cc-pagination__next-icon {
-  height: 12px;
+  height: 8px;
   margin-top: 1px;
 }
 
@@ -79,7 +86,8 @@
 }
 
 .cc-pagination__link.is-active {
-  font-weight: bold;
+  color: var(--colour-blue-60);
+  text-decoration: underline;
 }
 
 .cc-pagination .is-disabled > * {

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -72,7 +72,7 @@
 
 .cc-pagination__prev-icon,
 .cc-pagination__next-icon {
-  height: 8px;
+  height: calc(1 * var(--space-unit));
   margin-top: 1px;
 }
 

--- a/src/components/ResultsCount/ResultsCount.tsx
+++ b/src/components/ResultsCount/ResultsCount.tsx
@@ -20,7 +20,7 @@ export const ResultsCount = ({
 
   return (
     <div className={classNames}>
-      <p>
+      <p className="cc-results-count__result">
         Showing{' '}
         <strong>
           {currentCount} results of {resultsCount}

--- a/src/components/ResultsCount/_results-count.scss
+++ b/src/components/ResultsCount/_results-count.scss
@@ -18,7 +18,18 @@
   }
 }
 
+.cc-results-count__result {
+  margin-top: 0;
+
+  @include mq(sm) {
+    margin-bottom: 0;
+  }
+}
+
 .cc-results-count__sort {
+  margin-bottom: 0;
+  margin-top: 0;
+
   @include mq(sm) {
     margin-left: auto;
   }

--- a/src/components/SearchForm/_search-form.scss
+++ b/src/components/SearchForm/_search-form.scss
@@ -15,6 +15,7 @@
 
 .search-form--sidebar {
   display: block;
+  margin-top: 0;
 }
 
 .search-form__input {
@@ -50,10 +51,10 @@
 
 .search-form__btn {
   cursor: pointer;
-  padding-bottom: calc(2 * var(--space-unit));
+  padding-bottom: calc(2.375 * var(--space-unit));
   padding-left: calc(1.5 * var(--space-unit));
   padding-right: calc(3.125 * var(--space-unit));
-  padding-top: calc(2 * var(--space-unit));
+  padding-top: calc(2.375 * var(--space-unit));
   position: absolute;
   right: 0;
 }

--- a/src/components/SidebarFilter/_sidebar-filter.scss
+++ b/src/components/SidebarFilter/_sidebar-filter.scss
@@ -130,6 +130,11 @@
     border-color: var(--colour-blue-60);
   }
 
+  // Default checkbox
+  .cc-sidebar-filter__checkbox-input ~ &:before {
+    border-color: var(--colour-grey-40);
+  }
+
   // Disabled checkbox
   .cc-sidebar-filter__checkbox-input:disabled ~ &:before {
     border-color: var(--colour-grey-20);


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7954

- checkbox: change to the default grey colour 
- ResultsCount: update spacing
- Pagination: align with [Jason's design](https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/5fc78b10d77e9f0619dcb471)
- Standfirst: center-aligned
- Search on find grants awarded page: center the magnifier icon

![Screenshot 2021-01-19 at 15 12 38](https://user-images.githubusercontent.com/10700103/105053466-de715500-5a68-11eb-8bda-26d310f32bf4.png)
