### PR TITLE
#7911 feature: add forward ref to button 

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,9 @@
-import React, { MouseEvent as ReactMouseEvent, MouseEventHandler } from 'react';
+import React, {
+  forwardRef,
+  MouseEvent as ReactMouseEvent,
+  MouseEventHandler,
+  Ref
+} from 'react';
 import cx from 'classnames';
 
 import Icon from 'Icon/Icon';
@@ -22,65 +27,73 @@ type ButtonProps = {
   variant?: 'primary' | 'secondary' | 'ghost' | 'link' | 'unstyled';
 };
 
-export const Button = ({
-  autoFocus = false,
-  children,
-  className,
-  disabled,
-  href,
-  icon,
-  iconClassName,
-  iconPlacementSwitch,
-  id,
-  onClick,
-  role,
-  tabIndex,
-  textClassName,
-  type = 'button',
-  variant = 'primary'
-}: ButtonProps) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const Element: any = href ? Link : 'button';
-  const isUnstyled = variant !== 'unstyled';
-  const classNames = cx({
-    btn: isUnstyled,
-    [`btn--${variant}`]: isUnstyled,
-    [`${className}`]: className
-  });
-  const iconClassNames = cx('btn__icon', {
-    'btn__icon--left': !iconPlacementSwitch,
-    'btn__icon--right': iconPlacementSwitch,
-    [iconClassName]: iconClassName
-  });
-  const textClassNames = cx('btn__text', {
-    [textClassName]: textClassName
-  });
+export const Button = forwardRef(
+  (
+    {
+      autoFocus = false,
+      children,
+      className,
+      disabled,
+      href,
+      icon,
+      iconClassName,
+      iconPlacementSwitch,
+      id,
+      onClick,
+      role,
+      tabIndex,
+      textClassName,
+      type = 'button',
+      variant = 'primary',
+      ...props
+    }: ButtonProps,
+    ref: Ref<HTMLDivElement>
+  ) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const Element: any = href ? Link : 'button';
+    const isUnstyled = variant !== 'unstyled';
+    const classNames = cx({
+      btn: isUnstyled,
+      [`btn--${variant}`]: isUnstyled,
+      [`${className}`]: className
+    });
+    const iconClassNames = cx('btn__icon', {
+      'btn__icon--left': !iconPlacementSwitch,
+      'btn__icon--right': iconPlacementSwitch,
+      [iconClassName]: iconClassName
+    });
+    const textClassNames = cx('btn__text', {
+      [textClassName]: textClassName
+    });
 
-  return (
-    <Element
-      autoFocus={autoFocus}
-      className={classNames}
-      disabled={disabled}
-      to={href}
-      id={id}
-      onClick={(e: ReactMouseEvent) => {
-        if (onClick && !disabled) {
-          onClick(e);
-        }
-      }}
-      role={role}
-      tabIndex={tabIndex}
-      type={!href ? type : null}
-    >
-      {icon && !iconPlacementSwitch && (
-        <Icon name={icon} className={iconClassNames} />
-      )}
-      <span className={textClassNames}>{children}</span>
-      {icon && iconPlacementSwitch && (
-        <Icon name={icon} className={iconClassNames} />
-      )}
-    </Element>
-  );
-};
+    return (
+      <Element
+        autoFocus={autoFocus}
+        className={classNames}
+        disabled={disabled}
+        to={href}
+        id={id}
+        onClick={(e: ReactMouseEvent) => {
+          if (onClick && !disabled) {
+            onClick(e);
+          }
+        }}
+        ref={ref}
+        role={role}
+        tabIndex={tabIndex}
+        type={!href ? type : null}
+        {...props}
+      >
+        {icon && !iconPlacementSwitch && (
+          <Icon name={icon} className={iconClassNames} />
+        )}
+        <span className={textClassNames}>{children}</span>
+        {icon && iconPlacementSwitch && (
+          <Icon name={icon} className={iconClassNames} />
+        )}
+      </Element>
+    );
+  }
+);
 
 export default Button;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -47,7 +47,7 @@ export const Button = forwardRef(
       variant = 'primary',
       ...props
     }: ButtonProps,
-    ref: Ref<HTMLDivElement>
+    ref: Ref<HTMLButtonElement>
   ) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const Element: any = href ? Link : 'button';


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/7911

- add `forwardRef` to Button component
- this is to allow adding `ref` to a button (related PR: https://github.com/wellcometrust/corporate/issues/7911)