### PR TITLE
#8014 feature: updates src of video in Video to use Youtube enhanced …

### DIFF
--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -23,7 +23,7 @@ export const getYoutubeEmbedUrl = (src: string) => {
     '?wmode=opaque&modestbranding=1&rel=0&showinfo=0&color=white&autohide=1';
 
   return match !== null
-    ? `//www.youtube.com/embed/${match[2]}${embedOptions}`
+    ? `//www.youtube-nocookie.com/embed/${match[2]}${embedOptions}`
     : null;
 };
 


### PR DESCRIPTION
As part of the "unofficial" cookies audit we have been undertaking recently, it came to light that we should use Youtube's "enhanced privacy mode" when embedding YT videos on our site. An explanation of this mode from Google support below:

> "This means that no activity is collected to personalise the viewing experience. Instead, video recommendations are contextual and related to the current video. Videos playing in privacy-enhanced mode won't influence the viewer's browsing experience on YouTube."
> - https://support.google.com/youtube/answer/171780?hl=en-GB#zippy=%2Cturn-on-privacy-enhanced-mode

As far as I'm aware, Google (YouTube) will still track user behaviour in relation to the video, but will not use this to deliver any targeted videos etc. Presumably they still use this for internal analytics purposes (improving the UI, for example).

Relates to wellcometrust/corporate/issues/8014.

## This PR...

- updates Video to use the YouTube enhanced privacy mode URL