### PR TITLE
#8018 feat: focus state for checkboxes

### DIFF
--- a/config/storybook/styles/_storybook-global.scss
+++ b/config/storybook/styles/_storybook-global.scss
@@ -4,7 +4,7 @@
 
 // body vars
 body {
-  color: var(--colour-concrete-90);
+  color: var(--colour-grey-80);
   font-family: var(--font-primary);
   font-size: var(--text-base-size);
   letter-spacing: var(--body-letter-spacing);

--- a/src/assets/styles/10-settings/_colours.scss
+++ b/src/assets/styles/10-settings/_colours.scss
@@ -24,8 +24,6 @@
   --colour-blue-10: #dbeaff;
   --colour-blue-05: #f0f6ff;
 
-  --colour-concrete-90: #292929;
-
   --colour-cyan-20: #beebf4;
   --colour-cyan-05: #f1fcfd;
 

--- a/src/components/SidebarFilter/_sidebar-filter.scss
+++ b/src/components/SidebarFilter/_sidebar-filter.scss
@@ -124,10 +124,29 @@
     border: 0;
   }
 
-  // Hovered/Focused checkbox
-  .cc-sidebar-filter__checkbox-input:not(:disabled) ~ &:hover:before,
+  // Hovered checkbox
+  .cc-sidebar-filter__checkbox-input:not(:disabled) ~ &:hover:before {
+    border-color: var(--colour-grey-80);
+  }
+
+  /**
+   * @see focus-visible: https://css-tricks.com/focus-visible-and-backwards-compatibility/
+   */
+  // Focused checkbox
   .cc-sidebar-filter__checkbox-input:not(:disabled):focus ~ &:before {
-    border-color: var(--colour-blue-60);
+    box-shadow: 0 0 0 2px var(--colour-blue-30);
+  }
+
+  .cc-sidebar-filter__checkbox-input:not(:disabled):focus:not(:focus-visible) ~ &:before {
+    /**
+    * undo all the above focused styles
+    * if the input has focus but the browser wouldn't normally show default focus styles
+    */
+    box-shadow: none;
+  }
+
+  .cc-sidebar-filter__checkbox-input:not(:disabled):focus-visible ~ &:before {
+    box-shadow: 0 0 0 2px var(--colour-blue-30);
   }
 
   // Default checkbox

--- a/src/components/SidebarFilter/_sidebar-filter.scss
+++ b/src/components/SidebarFilter/_sidebar-filter.scss
@@ -137,11 +137,11 @@
     box-shadow: 0 0 0 2px var(--colour-blue-30);
   }
 
+  /**
+   * Browsers will ignore the entire block when using a pseudo-class they don’t understand/support
+   */
   .cc-sidebar-filter__checkbox-input:not(:disabled):focus:not(:focus-visible) ~ &:before {
-    /**
-    * undo all the above focused styles
-    * if the input has focus but the browser wouldn't normally show default focus styles
-    */
+    // undo all the above focused styles
     box-shadow: none;
   }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8018

- Add focus state for the checkboxes.
- Change hover border colour

I have used `:focus-visible` here and followed [the article about adding backwards compatibility for :focus-visible](https://css-tricks.com/focus-visible-and-backwards-compatibility/)

I decided to use it as I thought it would be a good idea to show focus only for the keyboard navigation, and not on hover.

I tested it in Chrome and Egde and it works as expected.

Please let me know your thoughts! :) 