### PR TITLE
#8044 feat: update contact component

### DIFF
--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -18,10 +18,6 @@ type InstitutionProps = {
 
 type ContactProps = {
   className?: string;
-  contactFormLink?: {
-    text?: string;
-    url: string;
-  };
   email?: string;
   imageSources?: ContactImageSourceProps;
   institutions?: InstitutionProps[];
@@ -35,7 +31,6 @@ type ContactProps = {
 
 export const Contact = ({
   className,
-  contactFormLink,
   email,
   imageSources,
   institutions,
@@ -95,14 +90,6 @@ export const Contact = ({
           <Icon name="email" className="cc-contact__link-icon" />
           <a href={`mailto:${email}`} className="cc-contact__link">
             {email}
-          </a>
-        </p>
-      )}
-      {contactFormLink && (
-        <p className="cc-contact__item">
-          <Icon name="email" className="cc-contact__link-icon" />
-          <a href={`${contactFormLink.url}`} className="cc-contact__link">
-            {contactFormLink.text || 'Send a message'}
           </a>
         </p>
       )}


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8044

`contactFormLink` was never implemented in the backend. The only place I was using it was on the funding guidance page.

[This CR PR](https://github.com/wellcometrust/corporate-react/pull/728) is updating the contact us section on the funding guidance page to match the rest of the site, so the `contactFormLink` prop is redundant now.