### PR TITLE
Bug/empty array non rendering #8053

### DIFF
--- a/src/components/FeaturedPromo/FeaturedPromo.stories.tsx
+++ b/src/components/FeaturedPromo/FeaturedPromo.stories.tsx
@@ -26,10 +26,14 @@ const FeaturedPromoExample = () => {
 
   return (
     <FeaturedPromo
-      authors={authors
-        .trim()
-        .split(',')
-        .map(a => a.trim())}
+      authors={
+        authors.trim().length
+          ? authors
+              .trim()
+              .split(',')
+              .map(a => a.trim())
+          : []
+      }
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
       description={parseHtml(description)}

--- a/src/components/FeaturedPromo/FeaturedPromo.tsx
+++ b/src/components/FeaturedPromo/FeaturedPromo.tsx
@@ -67,7 +67,7 @@ export const FeaturedPromo = ({
               {metaLabel}
             </span>
           )}
-          {authors?.length && (
+          {authors?.length > 0 && (
             <dl className="cc-featured-promo__meta-item cc-featured-promo__meta-item--author cc-featured-promo__authors">
               <dt className="cc-featured-promo__authors-label">Author</dt>
               {authors?.map(author => (

--- a/src/components/FullWidthPromo/FullWidthPromo.stories.tsx
+++ b/src/components/FullWidthPromo/FullWidthPromo.stories.tsx
@@ -45,10 +45,14 @@ const FullWidthPromoExample = () => {
 
   return (
     <FullWidthPromo
-      authors={authors
-        .trim()
-        .split(',')
-        .map(a => a.trim())}
+      authors={
+        authors.trim().length
+          ? authors
+              .trim()
+              .split(',')
+              .map(a => a.trim())
+          : []
+      }
       description={description}
       href={href}
       imageSrc={imageSrc}

--- a/src/components/FullWidthPromo/FullWidthPromo.tsx
+++ b/src/components/FullWidthPromo/FullWidthPromo.tsx
@@ -63,7 +63,7 @@ export const FullWidthPromo = ({
             {metaLabel && (
               <p className="cc-full-width-promo__type">{metaLabel}</p>
             )}
-            {authors?.length && (
+            {authors?.length > 0 && (
               <dl className="cc-full-width-promo__authors">
                 <dt className="cc-full-width-promo__authors-label">Author</dt>
                 {authors?.map(author => (
@@ -92,7 +92,7 @@ export const FullWidthPromo = ({
             {description}
           </RichText>
         )}
-        {!!linkText?.trim().length && (
+        {linkText?.trim().length > 0 && (
           <Button
             className="cc-full-width-promo__link cc-cta-link"
             href={href}

--- a/src/components/FullWidthPromo/_full-width-promo.scss
+++ b/src/components/FullWidthPromo/_full-width-promo.scss
@@ -84,14 +84,13 @@
   font-size: var(--body-xs);
   margin: 0;
   text-transform: uppercase;
-}
 
-.cc-full-width-promo__type + .cc-full-width-promo__authors:before {
-  color: var(--colour-amber-30);
-  content: '/';
-  font-size: var(--body-xs);
-  padding-left: var(--space-unit);
-  padding-right: var(--space-unit);
+  &:after {
+    color: var(--colour-amber-30);
+    content: '/';
+    padding-left: var(--space-unit);
+    padding-right: var(--space-unit);
+  }
 }
 
 .cc-full-width-promo__authors {

--- a/src/components/ImageCard/ImageCard.stories.tsx
+++ b/src/components/ImageCard/ImageCard.stories.tsx
@@ -26,10 +26,14 @@ const SingleImageCard = () => {
 
   return (
     <ImageCard
-      authors={authors
-        .trim()
-        .split(',')
-        .map(a => a.trim())}
+      authors={
+        authors.trim().length
+          ? authors
+              .trim()
+              .split(',')
+              .map(a => a.trim())
+          : []
+      }
       date={date}
       href={href}
       imageAlt={imageAlt}

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -68,7 +68,7 @@ export const ImageCard = ({
                 {metaLabel}
               </span>
             )}
-            {authors?.length && (
+            {authors?.length > 0 && (
               <dl className="cc-image-card__meta-item cc-image-card__meta-item--author cc-image-card__authors">
                 <dt className="cc-image-card__authors-label">Author</dt>
                 {authors?.map(author => (


### PR DESCRIPTION
This PR contains a fix for logic used to conditionally render card or promo authors. Short circuit logic returns the last item which is true so in the case of `authors?.length && <FullWidthPromo ... />` if there are no authors then a 0 is returned as `authors` is an empty array.

It's a minor point but `authors?.length > 0 && (` has been used instead of `!!authors?.length && (`. I believe this is instantly more readable than a forced boolean since the logic is explicitly saying we only render when the number of authors is greater than 0.