### PR TITLE
#8062 bug(style): sets overflow-x: auto; on RichText table wrap

### DIFF
--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -142,6 +142,6 @@
 }
 
 .cc-rich-text__table-wrap {
-  overflow-x: scroll;
+  overflow-x: auto;
   width: 100%;
 }


### PR DESCRIPTION
All `<table>` elements inside RichText components are causing an unnecessary horizontal scrollbar on Windows Chrome (and likely other Windows browsers) even when the content of the table fits inside the parent's width.

See wellcometrust/corporate/issues/8062

### This PR

- sets `overflow: auto;` rather than `overflow: scroll;` on the RichText table wrap

### To test

- `npm link` corporate-components https://github.com/wellcometrust/corporate-components/#2-setup-npm-link-for-local-development
- `npm run build` in local corporate-components repo
- update `.env` in corporate-react with `NEXT_PUBLIC_API_DOMAIN=https://cms.wellcome.org`
- `npm run dev`
- open http://localhost:3001/api/preview?slug=/news/safety-first-how-run-covid-19-vaccine-clinical-trial&revisionId=8603 in Windows 7 Chrome (use Browserstack)
- scroll until you see a `<table>` element
- check it has no scrollbars