### PR TITLE
 #8083 feature: add sidebar search

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -57,6 +57,7 @@
 @import './src/components/RadioInput/radio-input';
 @import './src/components/ResultsCount/results-count';
 @import './src/components/SidebarFilter/sidebar-filter';
+@import './src/components/SidebarSearch/sidebar-search';
 @import './src/components/SearchForm/search-form';
 @import './src/components/SearchPane/search-pane';
 @import './src/components/Section/section';

--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -11,12 +11,11 @@ type SidebarFilterProps = {
     value: string;
   }[];
   allowForceReset?: boolean;
-  children?: JSX.Element | JSX.Element[];
+  children?: JSX.Element;
   className?: string;
   onChange: (value: string) => void;
   onClear: () => void;
   onTagRemove: (value: string) => void;
-  searchComponent?: React.ReactNode;
   tags: {
     name: string;
     items: {
@@ -31,13 +30,12 @@ type SidebarFilterProps = {
 export const SidebarFilter = ({
   activeTags = [],
   allowForceReset,
+  children,
   className,
   onChange,
   onClear,
   onTagRemove,
-  searchComponent,
-  tags,
-  children
+  tags
 }: SidebarFilterProps) => {
   const classNames = cx('cc-sidebar-filter', {
     [className]: className
@@ -73,44 +71,42 @@ export const SidebarFilter = ({
           ))}
         </div>
       )}
-      {/* {searchComponent} */}
       {children}
-      <div>ewelina</div>
-      {/* <div className="cc-sidebar-filter__body"> */}
-      {/*  {tags.map(({ name, items }) => ( */}
-      {/*    <Accordion key={name} hasBorders> */}
-      {/*      <AccordionItem title={name}> */}
-      {/*        <ul className="cc-sidebar-filter__list"> */}
-      {/*          {items.map(item => ( */}
-      {/*            <li className="cc-sidebar-filter__list-item" key={item.value}> */}
-      {/*              /!* #7382 todo: add Checkbox component *!/ */}
-      {/*              <span className="cc-sidebar-filter__checkbox"> */}
-      {/*                <input */}
-      {/*                  checked={item.isActive} */}
-      {/*                  className="cc-sidebar-filter__checkbox-input" */}
-      {/*                  disabled={item.isDisabled} */}
-      {/*                  id={item.label} */}
-      {/*                  type="checkbox" */}
-      {/*                  onChange={() => onChange(item.value)} */}
-      {/*                /> */}
-      {/*                <label */}
-      {/*                  className="cc-sidebar-filter__checkbox-label" */}
-      {/*                  htmlFor={item.label} */}
-      {/*                > */}
-      {/*                  {item.label} */}
-      {/*                </label> */}
-      {/*                <Icon */}
-      {/*                  className="cc-sidebar-filter__checkbox-icon" */}
-      {/*                  name="checkmark" */}
-      {/*                /> */}
-      {/*              </span> */}
-      {/*            </li> */}
-      {/*          ))} */}
-      {/*        </ul> */}
-      {/*      </AccordionItem> */}
-      {/*    </Accordion> */}
-      {/*  ))} */}
-      {/* </div> */}
+      <div className="cc-sidebar-filter__body">
+        {tags.map(({ name, items }) => (
+          <Accordion key={name} hasBorders>
+            <AccordionItem title={name}>
+              <ul className="cc-sidebar-filter__list">
+                {items.map(item => (
+                  <li className="cc-sidebar-filter__list-item" key={item.value}>
+                    {/* #7382 todo: add Checkbox component */}
+                    <span className="cc-sidebar-filter__checkbox">
+                      <input
+                        checked={item.isActive}
+                        className="cc-sidebar-filter__checkbox-input"
+                        disabled={item.isDisabled}
+                        id={item.label}
+                        type="checkbox"
+                        onChange={() => onChange(item.value)}
+                      />
+                      <label
+                        className="cc-sidebar-filter__checkbox-label"
+                        htmlFor={item.label}
+                      >
+                        {item.label}
+                      </label>
+                      <Icon
+                        className="cc-sidebar-filter__checkbox-icon"
+                        name="checkmark"
+                      />
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </AccordionItem>
+          </Accordion>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -11,10 +11,12 @@ type SidebarFilterProps = {
     value: string;
   }[];
   allowForceReset?: boolean;
+  children?: JSX.Element | JSX.Element[];
   className?: string;
   onChange: (value: string) => void;
   onClear: () => void;
   onTagRemove: (value: string) => void;
+  searchComponent?: React.ReactNode;
   tags: {
     name: string;
     items: {
@@ -33,7 +35,9 @@ export const SidebarFilter = ({
   onChange,
   onClear,
   onTagRemove,
-  tags
+  searchComponent,
+  tags,
+  children
 }: SidebarFilterProps) => {
   const classNames = cx('cc-sidebar-filter', {
     [className]: className
@@ -60,6 +64,7 @@ export const SidebarFilter = ({
               className="cc-sidebar-filter__tags-list-item"
               icon="close"
               iconPlacementSwitch
+              key={value}
               onClick={() => onTagRemove(value)}
               type="button"
             >
@@ -68,41 +73,44 @@ export const SidebarFilter = ({
           ))}
         </div>
       )}
-      <div className="cc-sidebar-filter__body">
-        {tags.map(({ name, items }) => (
-          <Accordion key={name} hasBorders>
-            <AccordionItem title={name}>
-              <ul className="cc-sidebar-filter__list">
-                {items.map(item => (
-                  <li className="cc-sidebar-filter__list-item" key={item.value}>
-                    {/* #7382 todo: add Checkbox component */}
-                    <span className="cc-sidebar-filter__checkbox">
-                      <input
-                        checked={item.isActive}
-                        className="cc-sidebar-filter__checkbox-input"
-                        disabled={item.isDisabled}
-                        id={item.label}
-                        type="checkbox"
-                        onChange={() => onChange(item.value)}
-                      />
-                      <label
-                        className="cc-sidebar-filter__checkbox-label"
-                        htmlFor={item.label}
-                      >
-                        {item.label}
-                      </label>
-                      <Icon
-                        className="cc-sidebar-filter__checkbox-icon"
-                        name="checkmark"
-                      />
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </AccordionItem>
-          </Accordion>
-        ))}
-      </div>
+      {/* {searchComponent} */}
+      {children}
+      <div>ewelina</div>
+      {/* <div className="cc-sidebar-filter__body"> */}
+      {/*  {tags.map(({ name, items }) => ( */}
+      {/*    <Accordion key={name} hasBorders> */}
+      {/*      <AccordionItem title={name}> */}
+      {/*        <ul className="cc-sidebar-filter__list"> */}
+      {/*          {items.map(item => ( */}
+      {/*            <li className="cc-sidebar-filter__list-item" key={item.value}> */}
+      {/*              /!* #7382 todo: add Checkbox component *!/ */}
+      {/*              <span className="cc-sidebar-filter__checkbox"> */}
+      {/*                <input */}
+      {/*                  checked={item.isActive} */}
+      {/*                  className="cc-sidebar-filter__checkbox-input" */}
+      {/*                  disabled={item.isDisabled} */}
+      {/*                  id={item.label} */}
+      {/*                  type="checkbox" */}
+      {/*                  onChange={() => onChange(item.value)} */}
+      {/*                /> */}
+      {/*                <label */}
+      {/*                  className="cc-sidebar-filter__checkbox-label" */}
+      {/*                  htmlFor={item.label} */}
+      {/*                > */}
+      {/*                  {item.label} */}
+      {/*                </label> */}
+      {/*                <Icon */}
+      {/*                  className="cc-sidebar-filter__checkbox-icon" */}
+      {/*                  name="checkmark" */}
+      {/*                /> */}
+      {/*              </span> */}
+      {/*            </li> */}
+      {/*          ))} */}
+      {/*        </ul> */}
+      {/*      </AccordionItem> */}
+      {/*    </Accordion> */}
+      {/*  ))} */}
+      {/* </div> */}
     </div>
   );
 };

--- a/src/components/SidebarSearch/SidebarSearch.tsx
+++ b/src/components/SidebarSearch/SidebarSearch.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import cx from 'classnames';
+
+import Button from 'Button';
+
+type SidebarSearchProps = {
+  className?: string;
+  id: string;
+  label?: string;
+  onChange: () => void;
+  onClick: () => void;
+  onKeyDown: () => void;
+  onKeyUp: () => void;
+  value: string;
+};
+
+export const SidebarSearch = ({
+  className,
+  id,
+  label,
+  onChange,
+  onClick,
+  onKeyDown,
+  onKeyUp,
+  value
+}: SidebarSearchProps) => {
+  const classNames = cx('cc-sidebar-search', {
+    [className]: className
+  });
+
+  return (
+    <div className={classNames}>
+      <label htmlFor={`search-${id}`} className="cc-sidebar-search__label">
+        {label || 'Search by keyword'}
+      </label>
+      <input
+        className="cc-sidebar-search__input"
+        name={`search-${id}`}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        placeholder="e.g. fellowship"
+        value={value}
+        id={`search-${id}`}
+      />
+      <Button
+        className="cc-sidebar-search__btn"
+        icon="search"
+        iconClassName="u-mr-0 u-ml-0"
+        iconPlacementSwitch
+        onClick={onClick}
+        textClassName="u-visually-hidden"
+        variant="unstyled"
+      >
+        Search
+      </Button>
+    </div>
+  );
+};
+
+export default SidebarSearch;

--- a/src/components/SidebarSearch/SidebarSearch.tsx
+++ b/src/components/SidebarSearch/SidebarSearch.tsx
@@ -11,17 +11,19 @@ type SidebarSearchProps = {
   onClick: () => void;
   onKeyDown: () => void;
   onKeyUp: () => void;
+  placeholder?: string;
   value: string;
 };
 
 export const SidebarSearch = ({
   className,
   id,
-  label,
+  label = 'Search by keyword',
   onChange,
   onClick,
   onKeyDown,
   onKeyUp,
+  placeholder,
   value
 }: SidebarSearchProps) => {
   const classNames = cx('cc-sidebar-search', {
@@ -31,7 +33,7 @@ export const SidebarSearch = ({
   return (
     <div className={classNames}>
       <label htmlFor={`search-${id}`} className="cc-sidebar-search__label">
-        {label || 'Search by keyword'}
+        {label}
       </label>
       <input
         className="cc-sidebar-search__input"
@@ -39,7 +41,7 @@ export const SidebarSearch = ({
         onChange={onChange}
         onKeyDown={onKeyDown}
         onKeyUp={onKeyUp}
-        placeholder="e.g. fellowship"
+        placeholder={placeholder}
         value={value}
         id={`search-${id}`}
       />

--- a/src/components/SidebarSearch/_sidebar-search.scss
+++ b/src/components/SidebarSearch/_sidebar-search.scss
@@ -1,0 +1,30 @@
+// ----------------------------------
+// UI Components
+// Sidebar Search
+// ----------------------------------
+// Design System 1.0 Alpha
+// 2019-11-11
+// ----------------------------------
+
+.cc-sidebar-search {
+  display: block;
+  position: relative;
+}
+
+.cc-sidebar-search__input {
+  @extend %text-input-base;
+  border-color: var(--colour-grey-30);
+  font-size: inherit;
+  height: calc(6.75 * var(--space-unit));
+}
+
+.cc-sidebar-search__btn {
+  cursor: pointer;
+  padding-bottom: calc(2.375 * var(--space-unit));
+  padding-left: calc(1.5 * var(--space-unit));
+  padding-right: calc(3.125 * var(--space-unit));
+  padding-top: calc(2.375 * var(--space-unit));
+  position: absolute;
+  right: 0;
+  top: 26px;
+}

--- a/src/components/SidebarSearch/_sidebar-search.scss
+++ b/src/components/SidebarSearch/_sidebar-search.scss
@@ -11,6 +11,10 @@
   position: relative;
 }
 
+.cc-sidebar-search__label {
+  font-weight: bold;
+}
+
 .cc-sidebar-search__input {
   @extend %text-input-base;
   border-color: var(--colour-grey-30);

--- a/src/components/SidebarSearch/_sidebar-search.scss
+++ b/src/components/SidebarSearch/_sidebar-search.scss
@@ -30,5 +30,5 @@
   padding-top: calc(2.375 * var(--space-unit));
   position: absolute;
   right: 0;
-  top: 26px;
+  top: calc(3.5 * var(--space-unit));
 }

--- a/src/components/SidebarSearch/index.ts
+++ b/src/components/SidebarSearch/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SidebarSearch';

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export { Section } from 'Section/Section';
 export { SectionTitle } from 'SectionTitle/SectionTitle';
 export { default as SiteAlert } from 'SiteAlert';
 export { default as SidebarFilter } from 'SidebarFilter';
+export { default as SidebarSearch } from 'SidebarSearch';
 export { SlideshowHero } from 'SlideshowHero/SlideshowHero';
 export { SocialShare } from 'SocialShare/SocialShare';
 export { default as StatisticCard } from 'StatisticCard';


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8083

We are using the sidebar search on the grants awarded page and schemes page.

**Where is it used**

The search is a part of filters on the **schemes page**

![Screenshot 2021-02-05 at 13 51 22](https://user-images.githubusercontent.com/10700103/107042311-8309cb80-67b9-11eb-8c64-5f1ad47a33f9.png)

The search on **[grants awarded page](https://develop.wellcome-corporate-fe.org.uk/grant-funding/people-and-projects/grants-awarded)**

 