### PR TITLE
#8097 bug: fixes broken video test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wellcometrust/corporate-components",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wellcometrust/corporate-components",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Component library for main Wellcome Trust corporate site",
   "main": "dist/index.js",
   "style": "dist/styles.css",

--- a/src/components/Video/Video.test.tsx
+++ b/src/components/Video/Video.test.tsx
@@ -11,7 +11,7 @@ describe('getYoutubeEmbedUrl', () => {
 
   it('returns a correctly formatted YouTube embed code', () => {
     expect(outputValid).toBe(
-      '//www.youtube.com/embed/Ha63EJhGoBw?wmode=opaque&modestbranding=1&rel=0&showinfo=0&color=white&autohide=1'
+      '//www.youtube-nocookie.com/embed/Ha63EJhGoBw?wmode=opaque&modestbranding=1&rel=0&showinfo=0&color=white&autohide=1'
     );
   });
 


### PR DESCRIPTION
Fixes the broken Video.test.tsx file caused by an update to the Video component.

Full error details at wellcometrust/corporate/issues/8097

### This PR

- updates Video.test.tsx to test against updated output from Video.tsx changes

### To test

- pull down this branch
- `npm run test`