### PR TITLE
#8026 feature: adds consent messaging to Video captions

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -72,4 +72,5 @@
 @import './src/components/TextCard/text-card';
 @import './src/components/TextInput/text-input';
 @import './src/components/Timeline/timeline';
+@import './src/components/Video/video';
 @import './src/components/WellcomeCollectionBanner/wellcome-collection-banner';

--- a/src/components/Media/_media.scss
+++ b/src/components/Media/_media.scss
@@ -84,23 +84,3 @@
     display: inline;
   }
 }
-
-.widescreen-container {
-  position: relative;
-  width: 100%;
-
-  &:after {
-    content: '';
-    display: block;
-    padding-top: percentage(9/16);
-  }
-}
-
-.widescreen-media {
-  border: 0;
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}

--- a/src/components/Video/Video.stories.tsx
+++ b/src/components/Video/Video.stories.tsx
@@ -13,7 +13,14 @@ const VideoExample = () => {
     'https://www.youtube.com/watch?v=Ha63EJhGoBw&feature=youtu.be'
   );
 
-  return <Video caption={CaptionText} credit={CreditText} src={VideoSource} />;
+  return (
+    <Video
+      caption={CaptionText}
+      credit={CreditText}
+      id="video"
+      src={VideoSource}
+    />
+  );
 };
 
 const stories = storiesOf('Components|Video', module);

--- a/src/components/Video/Video.test.tsx
+++ b/src/components/Video/Video.test.tsx
@@ -22,7 +22,12 @@ describe('getYoutubeEmbedUrl', () => {
 
 describe('<Video />', () => {
   const output = shallow(
-    <Video src="video" caption="Video caption" credit="Video credit" />
+    <Video
+      caption="Video caption"
+      credit="Video credit"
+      id="video"
+      src="video"
+    />
   );
 
   it('renders the component', () => {

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Link from 'Link';
 import Media from 'Media';
 
 type VideoProps = {
@@ -43,13 +44,24 @@ export const Video = ({
       credit={credit}
       licence={licence}
     >
-      <div className="widescreen-container">
-        <iframe
-          allowFullScreen
-          className="widescreen-media"
-          src={embedSrc}
-          title={caption}
-        />
+      <div className="cc-video">
+        <div className="cc-video__inner">
+          <iframe
+            allowFullScreen
+            className="cc-video__iframe"
+            src={embedSrc}
+            title={caption}
+            aria-describedby="youtube-consent"
+          />
+        </div>
+        <p className="cc-video__caption" id="youtube-consent">
+          Pressing play on the video above will set a third-party cookie. Please
+          read our{' '}
+          <Link to="/about-us/governance/privacy-and-terms#cookies">
+            cookie policy
+          </Link>{' '}
+          for more information.
+        </p>
       </div>
     </Media>
   );

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -7,6 +7,7 @@ type VideoProps = {
   caption?: string;
   credit?: string;
   className?: string;
+  id: string;
   licence?: string;
   src: string;
 };
@@ -32,6 +33,7 @@ export const Video = ({
   caption,
   credit,
   className,
+  id,
   licence,
   src
 }: VideoProps) => {
@@ -44,17 +46,17 @@ export const Video = ({
       credit={credit}
       licence={licence}
     >
-      <div className="cc-video">
+      <div className="cc-video" id={id}>
         <div className="cc-video__inner">
           <iframe
             allowFullScreen
             className="cc-video__iframe"
             src={embedSrc}
             title={caption}
-            aria-describedby="youtube-consent"
+            aria-describedby={`${id}-consent`}
           />
         </div>
-        <p className="cc-video__caption" id="youtube-consent">
+        <p className="cc-video__caption" id={`${id}-consent`}>
           Pressing play on the video above will set a third-party cookie. Please
           read our{' '}
           <Link to="/about-us/governance/privacy-and-terms#cookies">

--- a/src/components/Video/_video.scss
+++ b/src/components/Video/_video.scss
@@ -1,0 +1,32 @@
+// ----------------------------------
+// UI Components
+// Video
+// ----------------------------------
+// Design System 1.0 Alpha
+// 2019-11-11
+// ----------------------------------
+
+.cc-video__inner {
+  position: relative;
+  width: 100%;
+
+  &:after {
+    content: '';
+    display: block;
+    padding-top: percentage(9/16);
+  }
+}
+
+.cc-video__iframe {
+  border: 0;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.cc-video__caption {
+  font-size: var(--body-sm);
+  margin-bottom: 0;
+}


### PR DESCRIPTION
For GDPR compliance we want to display a message to users beneath Youtube videos embedded on wellcome.org informing that by playing the video they consent to their behaviour within the video player itself being tracked by Google (Youtube).

This messaging has been copied directly from the ICO website (e.g. https://ico.org.uk/global/privacy-notice/).

## This PR

- updates Video.tsx to render some text in the UI
- adds stylesheet partial for _video.scss
- renames & moves `.widescreen-container` style rules to _video.scss (seems more appropriate there)

## To test

- pull this branch
- ensure corporate-components is `npm link`ed (see Readme in this repo)
- set `NEXT_PUBLIC_API_DOMAIN=https://cms.wellcome.org` in corporate-react's .env file
- run `npm run build` from corporate-components
- run `npm run dev` from corporate-react
- open http://localhost:3001/news/what-different-types-covid-19-vaccine-are-there
- you should see the new text beneath the video
- clicking link inside the text should take you to /about-us/governance/privacy-and-terms#cookies