### PR TITLE
#8109 feature: adds reverse arrow icon

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -12,6 +12,8 @@ storiesOf('Components|Icon', module).add(
       <Icon name="arrow" />
       <p>ArrowLong</p>
       <Icon name="arrowLong" />
+      <p>ArrowReverse</p>
+      <Icon name="arrowReverse" />
       <p>Checkmark</p>
       <Icon name="checkmark" />
       <p>Chevron</p>

--- a/src/components/Icon/components/ArrowReverse.tsx
+++ b/src/components/Icon/components/ArrowReverse.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { IconSVGProps } from '../Icon';
+
+const ArrowReverse = (props: IconSVGProps) => (
+  <svg viewBox="0 0 12 12" {...props}>
+    <path
+      d="M12 6.8H3.4l3.1 3.9-.8.8L0 6 5.7.5l.8.8-3.1 3.9H12v1.6z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+export default ArrowReverse;

--- a/src/components/Icon/iconMapping.ts
+++ b/src/components/Icon/iconMapping.ts
@@ -1,5 +1,6 @@
 import arrow from './components/Arrow';
 import arrowLong from './components/ArrowLong';
+import arrowReverse from './components/ArrowReverse';
 import checkmark from './components/Checkmark';
 import chevron from './components/Chevron';
 import chevronDown from './components/ChevronDown';
@@ -31,6 +32,7 @@ import youTube from './components/YouTube';
 export default new Map([
   ['arrow', arrow],
   ['arrowLong', arrowLong],
+  ['arrowReverse', arrowReverse],
   ['checkmark', checkmark],
   ['chevron', chevron],
   ['chevronDown', chevronDown],


### PR DESCRIPTION
In order to display a Button which has an arrow pointing to the left (as part of https://github.com/wellcometrust/corporate/issues/7304) I've added an `arrowReverse` icon to the Icon set.

## This PR

- adds ArrowReverse.tsx
- imports/exports ArrowReverse in icon-mapping.tsx
- adds ArrowReverse to Icon.stories.tsx

## To test

- `npm run storybook`
- Open Icon story
- See "ArrowReverse"