### PR TITLE
#8111 feature(refactor): sets SearchFormInput name attribute to static value

### DIFF
--- a/src/components/SearchForm/SearchFormInput.tsx
+++ b/src/components/SearchForm/SearchFormInput.tsx
@@ -22,7 +22,7 @@ export const SearchFormInput = ({
   return (
     <input
       className={classNames}
-      name={id}
+      name="search"
       type="search"
       placeholder="Search wellcome.org"
       onChange={handleChange}


### PR DESCRIPTION
Context: The SearchForm requires `<input name="search"/>` in order to work correctly, however currently we have `<input name={inputId} id={inputId} />` rendered from within the SearchForm component. The problem with this is that `inputId` must always be set to `search`, meaning if we have multiple `SearchForm` components on the page we end up rendering:

```
<input id="search" name="search" />
// ... some more HTML
<input id="search" name="search" />
```

The problem is duplicate IDs. See https://github.com/wellcometrust/corporate/issues/8111 for further information.

## This PR

- sets `name="search"` in SearchFormInput

## To test

- Link corporate-components from corporate-react (see Readme.md of corporate-components)
- `npm run dev` in both corporate-react & corporate-components
- Open `https://localhost:3001/search`
- Change value of `inputId` from corporate-react/src/components/SearchResultsList/SearchResultsList.tsx
- Inspect DOM in browser
- See that `id` attribute of the `<input type="search" />` within the SearchResultsList component changes
- See that `name` attribute of the `<input type="search" />` within the SearchResultsList component does not change