### PR TITLE
#8120: feat add select to ResultsCount

### DIFF
--- a/src/components/FormSelect/form-select.scss
+++ b/src/components/FormSelect/form-select.scss
@@ -10,9 +10,10 @@
   @extend %text-input-base;
   appearance: none;
   background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 17 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12.9347 5L8.43458 9.20018L3.93446 5L2.43506 6.39946L8.43458 12L14.4351 6.39946L12.9347 5Z' fill='black'/%3E%3C/svg%3E");
-  background-position: 98% center;
+  background-position: 94% center;
   background-repeat: no-repeat;
   background-size: 12px 12px;
+  padding-right: calc(3 * var(--space-unit));
 
   // IE11
   &::-ms-expand {

--- a/src/components/ResultsCount/ResultsCount.tsx
+++ b/src/components/ResultsCount/ResultsCount.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
 import cx from 'classnames';
+import Label from '../Label';
 
 type ResultsCountProps = {
   className?: string;
   currentCount: string;
+  id?: string;
+  onChange?: () => void;
+  options?: {
+    label: string;
+    value: string;
+  }[];
   resultsCount: number;
-  sortedBy: string;
+  selectedValue?: string;
+  sortedBy?: string;
 };
 
 export const ResultsCount = ({
   className,
   currentCount,
+  id,
+  onChange,
+  options,
   resultsCount,
+  selectedValue,
   sortedBy
 }: ResultsCountProps) => {
   const classNames = cx('cc-results-count', {
@@ -26,7 +38,30 @@ export const ResultsCount = ({
           {currentCount} results of {resultsCount}
         </strong>
       </p>
-      <p className="cc-results-count__sort">Sorted by {sortedBy}</p>
+      {sortedBy && (
+        <p className="cc-results-count__sort">Sorted by {sortedBy}</p>
+      )}
+      {options && (
+        <div className="cc-results-count__sort">
+          <Label
+            className="cc-results-count__label"
+            htmlFor={id}
+            text="Sort by:"
+          />
+          <select
+            className="cc-select cc-results-count__select"
+            id={id}
+            onChange={onChange}
+            value={selectedValue}
+          >
+            {options?.map(option => (
+              <option key={`option-${option.label}`} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/ResultsCount/ResultsCount.tsx
+++ b/src/components/ResultsCount/ResultsCount.tsx
@@ -38,10 +38,7 @@ export const ResultsCount = ({
           {currentCount} results of {resultsCount}
         </strong>
       </p>
-      {sortedBy && (
-        <p className="cc-results-count__sort">Sorted by {sortedBy}</p>
-      )}
-      {options && (
+      {options ? (
         <div className="cc-results-count__sort">
           <Label
             className="cc-results-count__label"
@@ -61,6 +58,8 @@ export const ResultsCount = ({
             ))}
           </select>
         </div>
+      ) : (
+        <p className="cc-results-count__sort">Sorted by {sortedBy}</p>
       )}
     </div>
   );

--- a/src/components/ResultsCount/ResultsCount.tsx
+++ b/src/components/ResultsCount/ResultsCount.tsx
@@ -59,7 +59,9 @@ export const ResultsCount = ({
           </select>
         </div>
       ) : (
-        <p className="cc-results-count__sort">Sorted by {sortedBy}</p>
+        sortedBy && (
+          <p className="cc-results-count__sort">Sorted by {sortedBy}</p>
+        )
       )}
     </div>
   );

--- a/src/components/ResultsCount/_results-count.scss
+++ b/src/components/ResultsCount/_results-count.scss
@@ -39,6 +39,7 @@
 
 .cc-results-count__label {
   @include mq(sm) {
+    margin-bottom: 0;
     margin-right: calc(0.75 * var(--space-unit));
   }
 }

--- a/src/components/ResultsCount/_results-count.scss
+++ b/src/components/ResultsCount/_results-count.scss
@@ -31,6 +31,20 @@
   margin-top: 0;
 
   @include mq(sm) {
+    align-items: center;
+    display: flex;
     margin-left: auto;
+  }
+}
+
+.cc-results-count__label {
+  @include mq(sm) {
+    margin-right: calc(0.75 * var(--space-unit));
+  }
+}
+
+.cc-results-count__select {
+  @include mq(sm) {
+    width: 238px;
   }
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8120

- add select to ResultsCount component
- used on the `Find a scheme` page

![Screenshot 2021-02-15 at 14 54 05](https://user-images.githubusercontent.com/10700103/107961393-c2949c80-6f9d-11eb-9630-2f292ab45af1.png)
