### PR TITLE
Add margin below header when it has a background colour #7944

### DIFF
--- a/src/components/PageHeader/_page-header.scss
+++ b/src/components/PageHeader/_page-header.scss
@@ -4,6 +4,7 @@
 
 .cc-page-header--blue {
   background-color: var(--colour-blue-05);
+  margin-bottom: var(--space-xl);
 }
 
 .cc-page-header__container {


### PR DESCRIPTION
When we have blue background header, we need a margin below the header, otherwise there is no space between the blue background and the content that follows . 

Fahim has specified the margin should be 64px in desktop mode, so I assume `--space-xl` is correct. As far as I can tell `.cc-page-header--blue` is only used in this very specific context, so this rule won't affect anything else.

See https://app.zenhub.com/workspaces/wellcomeorg-563935e740685bbb4db701bf/issues/wellcometrust/corporate/7944