### PR TITLE
#8121 bug: fixes lint-staged command

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,13 +144,11 @@
     "typescript": "^3.7.4"
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx}": [
-      "npm run lint:js",
-      "git add"
+    "*.{js,jsx,ts,tsx}": [
+      "npm run lint:js"
     ],
     "src/**/*.{scss,css}": [
-      "npm run lint:style",
-      "git add"
+      "npm run lint:style"
     ]
   },
   "husky": {


### PR DESCRIPTION
The "lint-staged" command which runs as part of the husky pre-commit hook is currently not linting any files. 

See wellcometrust/corporate/issues/8121 for further information.

## This PR

- updates the lint-staged command in package.json so that it runs on relevant files

## To test

- checkout a junk branch `git checkout -b junk/test-lint-staged`
- make some changes in the repo which you know should flag a linting error
- commit the changes `git add --all && git commit -m "linter should flag"
- the commit should fail