### PR TITLE
#8135 bug: News landing - CTA with faded background

### DIFF
--- a/src/assets/styles/20-tools/_mixins/_sticky.scss
+++ b/src/assets/styles/20-tools/_mixins/_sticky.scss
@@ -21,7 +21,7 @@
  *
  */
 
-@mixin sticky-fade {
+@mixin sticky-fade($top: -80px, $bottom: 0) {
   @include mq(md) {
     position: relative;
   }
@@ -31,13 +31,13 @@
   &:after {
     @include mq(md) {
       background: linear-gradient(180deg, var(--hack-safari-transparent-white) 0, var(--colour-white) 10%, var(--colour-white) 90%, var(--hack-safari-transparent-white) 100%);
-      bottom: -80px;
+      bottom: $bottom;
       content: '';
       left: 0;
       pointer-events: none;
       position: absolute;
       right: 0;
-      top: -80px;
+      top: $top;
       z-index: 0;
     }
   }


### PR DESCRIPTION
Adjusted faded background applied to wide scaffolded items to prevent overlap of adjacent content as in the screenshot below.

<img width="992" alt="Screenshot 2021-02-17 at 10 16 00" src="https://user-images.githubusercontent.com/49439125/108204327-90a94480-711b-11eb-8194-cee9925225c0.png">
