### PR TITLE
#8161 feature: removes rel, target attributes from FileDownload component

### DIFF
--- a/src/components/FileDownload/FileDownload.tsx
+++ b/src/components/FileDownload/FileDownload.tsx
@@ -35,8 +35,6 @@ export const FileDownload = ({
         data-report-type={documentSubType}
         download
         href={href}
-        rel="noopener noreferrer"
-        target="_blank"
       >
         {label}
         <span className="u-visually-hidden">{` ${name}`}</span>


### PR DESCRIPTION
Design/UX QA of the listing pages deemed that hrefs to files should not be opened in a new window.

This PR removes the `rel` and `target` attributes from the FileDownload component so that this takes effect site-wide.

See wellcometrust/corporate/issues/8161 for further information.