### PR TITLE
#8164 feature(style): decreases margins in ListingLink component

### DIFF
--- a/src/components/Listing/ListingLink/ListingLink.tsx
+++ b/src/components/Listing/ListingLink/ListingLink.tsx
@@ -42,14 +42,11 @@ export const ListingLink = ({
         data-report-type={documentSubType}
         to={href}
       >
-        {title}
+        <span className="cc-listing__link-text">{title}</span>
         {fileType && fileSize && (
-          <>
-            {' '}
-            <span className="cc-listing__link-meta">
-              {fileType} {fileSize}
-            </span>
-          </>
+          <span className="cc-listing__link-meta">
+            {fileType} {fileSize}
+          </span>
         )}
         <Icon name={iconVariant} className={iconClassNames} />
       </Link>

--- a/src/components/Listing/_listing.scss
+++ b/src/components/Listing/_listing.scss
@@ -39,10 +39,13 @@
   text-decoration: none;
 }
 
+.cc-listing__link-text {
+  margin-right: var(--space-unit);
+}
+
 .cc-listing__link-meta {
   color: var(--text-colour);
   font-size: var(--body-xs);
-  margin-left: calc(2 * var(--space-unit));
 }
 
 .cc-listing__link-icon {


### PR DESCRIPTION
Design QA of the /what-we-do/reports listing page deemed that the spacing in the ListingLink component was too wide, between the "title" text and fileType/fileMeta text.

This PR reduces the margin between those elements.

See https://github.com/wellcometrust/corporate/issues/8164 for more information.