### PR TITLE
#8177 bug: fix select arrow icon position

### DIFF
--- a/src/components/FormSelect/form-select.scss
+++ b/src/components/FormSelect/form-select.scss
@@ -10,10 +10,10 @@
   @extend %text-input-base;
   appearance: none;
   background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 17 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12.9347 5L8.43458 9.20018L3.93446 5L2.43506 6.39946L8.43458 12L14.4351 6.39946L12.9347 5Z' fill='black'/%3E%3C/svg%3E");
-  background-position: 94% center;
+  background-position: right calc(2 * var(--space-unit)) center;
   background-repeat: no-repeat;
   background-size: 12px 12px;
-  padding-right: calc(3 * var(--space-unit));
+  padding-right: calc(4 * var(--space-unit));
 
   // IE11
   &::-ms-expand {


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8177

I added a bit of space to the arrow icon but this caused that long selects had a bigger gap:

Example:

![Screenshot 2021-02-22 at 10 58 38](https://user-images.githubusercontent.com/10700103/108714317-507a0580-7511-11eb-8bcb-e7fe51608e66.png)

link on develop: https://develop.wellcome-corporate-fe.org.uk/grant-funding/guidance-listing

This PR is fixing that.

**Select after changes**

Longer select:

![Screenshot 2021-02-22 at 13 25 15](https://user-images.githubusercontent.com/10700103/108714431-6daed400-7511-11eb-92a8-51855761d3ff.png)

Shorter select (e.g. in a sidebar):

![Screenshot 2021-02-22 at 13 26 03](https://user-images.githubusercontent.com/10700103/108714507-87e8b200-7511-11eb-84da-bfc1d831abc6.png)


**To test**
- pull this branch (make sure to run npm link etc.)
- for short select example check: http://localhost:3001/grant-funding/people-and-projects/grants-awarded
- for longer select check: http://localhost:3001/grant-funding/guidance-listing




