### PR TITLE
#7930 feature: adds QuickLinks component

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -57,6 +57,7 @@
 @import './src/components/PageHeaderCompact/page-header-compact';
 @import './src/components/PageTitle/page-title';
 @import './src/components/Pagination/pagination';
+@import './src/components/QuickLinks/quick-links';
 @import './src/components/Quote/quote';
 @import './src/components/RadioInput/radio-input';
 @import './src/components/ResultsCount/results-count';

--- a/src/components/QuickLinks/QuickLinks.stories.tsx
+++ b/src/components/QuickLinks/QuickLinks.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { number, text } from '@storybook/addon-knobs';
+
+import QuickLinks from './QuickLinks';
+
+const QuickLinksExample = () => {
+  const className = text('className', '', 'General');
+  const numberOfItems = number('numberOfItems', 5, {}, 'General');
+
+  const initialItems = [
+    {
+      href: '/grant-funding',
+      label: 'Find funding opportunities'
+    },
+    {
+      href: '/grant-tracker',
+      label: 'Log in to Grant Tracker'
+    },
+    {
+      href: 'https://wtgrants.wellcome.org/Login.aspx',
+      label: 'Read funding guidance'
+    },
+    {
+      href: '/grant-funding/guidance',
+      label: 'Learn about Wellcome'
+    },
+    {
+      href:
+        '/grant-funding/guidance/coronavirus-covid-19-information-grant-applicants-and-grantholders',
+      label: 'Read COVID-19 information for grantholders and grant applicants'
+    }
+  ];
+  const items = [...Array(numberOfItems).keys()].map(i => ({
+    href: text('href (url)', initialItems[i].href, `Item ${i + 1}`),
+    label: text('label', initialItems[i].label, `Item ${i + 1}`)
+  }));
+
+  return <QuickLinks className={className} items={items} />;
+};
+
+const stories = storiesOf('QuickLinks', module);
+
+stories.add('QuickLinks', QuickLinksExample);

--- a/src/components/QuickLinks/QuickLinks.tsx
+++ b/src/components/QuickLinks/QuickLinks.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import cx from 'classnames';
+
+import Link from 'Link';
+
+type QuickLinksProps = {
+  className?: string;
+  items: {
+    href: string;
+    label: string;
+  }[];
+};
+
+export const QuickLinks = ({ className, items }: QuickLinksProps) => {
+  const classNames = cx('c-quick-links', {
+    className
+  });
+  return (
+    <ul className={classNames}>
+      {items.map(({ href, label }) => (
+        <li className="c-quick-links__item">
+          <Link className="c-quick-links__item-link" to={href}>
+            {label}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default QuickLinks;

--- a/src/components/QuickLinks/QuickLinks.tsx
+++ b/src/components/QuickLinks/QuickLinks.tsx
@@ -15,10 +15,11 @@ export const QuickLinks = ({ className, items }: QuickLinksProps) => {
   const classNames = cx('c-quick-links', {
     className
   });
+
   return (
     <ul className={classNames}>
-      {items.map(({ href, label }) => (
-        <li className="c-quick-links__item">
+      {items.map(({ href, label }, i) => (
+        <li className="c-quick-links__item" key={`quick-links-item-${i + 1}`}>
           <Link className="c-quick-links__item-link" to={href}>
             {label}
           </Link>

--- a/src/components/QuickLinks/_quick-links.scss
+++ b/src/components/QuickLinks/_quick-links.scss
@@ -19,8 +19,7 @@
   padding-top: calc(1.5 * var(--space-unit));
   text-decoration: none;
 
-  &:hover,
-  &:focus {
+  @include hocus {
     text-decoration: underline;
   }
 }

--- a/src/components/QuickLinks/_quick-links.scss
+++ b/src/components/QuickLinks/_quick-links.scss
@@ -15,8 +15,8 @@
 .c-quick-links__item-link {
   color: inherit;
   display: block;
-  padding-top: calc(1.5 * var(--space-unit));
   padding-bottom: calc(1.5 * var(--space-unit));
+  padding-top: calc(1.5 * var(--space-unit));
   text-decoration: none;
 
   &:hover,

--- a/src/components/QuickLinks/_quick-links.scss
+++ b/src/components/QuickLinks/_quick-links.scss
@@ -1,0 +1,26 @@
+// ----------------------------------
+// UI Components
+// QuickLinks
+// ----------------------------------
+// Design System 1.0 Alpha
+// 2019-11-11
+// ----------------------------------
+
+.c-quick-links {
+  @include list-clean;
+}
+
+// .c-quick-links__item {}
+
+.c-quick-links__item-link {
+  color: inherit;
+  display: block;
+  padding-top: calc(1.5 * var(--space-unit));
+  padding-bottom: calc(1.5 * var(--space-unit));
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+}

--- a/src/components/QuickLinks/index.ts
+++ b/src/components/QuickLinks/index.ts
@@ -1,0 +1,1 @@
+export { default } from './QuickLinks';

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export { default as ImageCard } from 'ImageCard';
 export { default as ImageCardWithCTA } from 'ImageCardWithCTA';
 export { NewsletterSignup } from 'NewsletterSignup/NewsletterSignup';
 export { NewsletterForm } from 'NewsletterForm/NewsletterForm';
+export { default as QuickLinks } from 'QuickLinks';
 export { Quote } from 'Quote/Quote';
 export { PageHeader } from 'PageHeader/PageHeader';
 export { default as PageHeaderCompact } from 'PageHeaderCompact';


### PR DESCRIPTION
# Description

As part of the UI updates taking place on the .org homepage we are updating the "Quick links" panel which is currently displayed on the right-hand side of the homepage (desktop) on https://wellcome.org.

It could be argued that this component should live in corporate-react. I have chosen to build it within corporate-components as that was the convention for the MissionStatement component ([PR](https://github.com/wellcometrust/corporate-components/pull/388)) which will be used in a similar way (on the .org homepage).

I am open to suggestions as to whether both of these components should live in corporate-react, and wouldn't mind closing these PRs are re-opening them on corporate-react if that is consensus.

See /wellcometrust/corporate/issues/7930 for further information.

Zeplin: https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/5f803212f498fd5904bab2f5

# To test

1. Pull the branch
2. `npm run storybook`
3. Open "QuickLinks" from left-hand sidebar
4. Inspect component
5. Check against design in Zeplin https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/5f803212f498fd5904bab2f5