### PR TITLE
#8154 feat: update nested accordion styles

### DIFF
--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -130,7 +130,7 @@
   }
 
   .cc-accordion__button--plus {
-    font-size: var(--body-md);
+    font-size: var(--heading-xs);
     font-weight: normal;
   }
 

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -35,7 +35,6 @@
   }
 
   .cc-accordion + *,
-  .cc-accordion + *,
   .cc-rich-text + * {
     margin-top: calc(2 * var(--space-sm));
   }

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -30,6 +30,11 @@
 .cc-accordion__content {
   padding: var(--space-unit) 0;
 
+  h3 {
+    font-size: var(--heading-sm);
+  }
+
+  .cc-accordion + *,
   .cc-accordion + *,
   .cc-rich-text + * {
     margin-top: calc(2 * var(--space-sm));
@@ -125,6 +130,7 @@
   }
 
   .cc-accordion__button--plus {
+    font-size: var(--body-md);
     font-weight: normal;
   }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8154

### Context

 the font size for the title inside accordion was bigger than the accordion title

Design: https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/603538df84f6342c116c1d13

### This PR:

- adds 14px font size for nested accordion title,
- fixes bigger title inside accordion that accordion title

BEFORE:

![Screenshot 2021-02-24 at 17 30 58](https://user-images.githubusercontent.com/10700103/109040753-2b7ac380-76c6-11eb-9cce-62afe294d621.png)

AFTER:

![Screenshot 2021-02-24 at 17 32 56](https://user-images.githubusercontent.com/10700103/109040907-5bc26200-76c6-11eb-88ab-d090073ab2bd.png)




