### PR TITLE
8153 task(style): add primary InfoBox style

### DIFF
--- a/src/components/InfoBox/InfoBox.stories.tsx
+++ b/src/components/InfoBox/InfoBox.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text } from '@storybook/addon-knobs';
+import { select, text } from '@storybook/addon-knobs';
 
 import Contact from 'Contact';
 import Listing from 'Listing';
@@ -10,10 +10,11 @@ import InfoBox from './InfoBox';
 import Readme from './InfoBox.md';
 
 const InfoBoxExample = () => {
-  const titleText = text('title', 'Info box title');
+  const titleText = text('Title', 'Info box title');
+  const variant = select('Variant', ['primary', 'secondary'], 'secondary');
 
   return (
-    <InfoBox>
+    <InfoBox variant={variant}>
       <Text title={titleText} variant="text-snippet">
         {`<p>This new funding should be directed to a global response for:</p>
         <h2>Heading 2</h2>

--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -4,11 +4,17 @@ import cx from 'classnames';
 type InfoBoxProps = {
   children: React.ReactNode;
   className?: string;
+  variant?: 'primary' | 'secondary';
 };
 
-export const InfoBox = ({ children, className }: InfoBoxProps) => {
+export const InfoBox = ({
+  children,
+  className,
+  variant = 'secondary'
+}: InfoBoxProps) => {
   const classNames = cx('cc-info-box', {
-    [`${className}`]: className
+    'cc-info-box--primary': variant === 'primary',
+    [className]: className
   });
 
   return <div className={classNames}>{children}</div>;

--- a/src/components/InfoBox/_info-box.scss
+++ b/src/components/InfoBox/_info-box.scss
@@ -7,7 +7,7 @@
 // ----------------------------------
 
 .cc-info-box {
-  background: var(--colour-cyan-05);
+  background-color: var(--colour-cyan-05);
   color: var(--colour-grey-80);
   margin-bottom: var(--space-xl);
   padding: calc(4 * var(--space-unit));
@@ -15,5 +15,9 @@
   > :last-child {
     margin-bottom: 0;
   }
+}
+
+.cc-info-box--primary {
+  border: 1px solid var(--colour-blue-30);
 }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8153

### Context

Allow adding a primary InfoBox

design: https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/5fca6e737c3304443589aa79

### This PR

- adds a primary variant to InfoBox
- update InfoBox story

![Screenshot 2021-03-04 at 18 31 30](https://user-images.githubusercontent.com/10700103/110011943-dff49500-7d17-11eb-9b93-97d1e4d93230.png)

### To test
1. `git fetch origin task/8153-primary-infobox`
2. `git checkout task/8153-primary-infobox`
3.  pull CR PR: https://github.com/wellcometrust/corporate-react/pull/815
4. run `npm link` if necessary
5. go to http://localhost:3001/node/5664

