### PR TITLE
Feature 8272: On text cards, title may not be present

### DIFF
--- a/src/components/TextCard/TextCard.tsx
+++ b/src/components/TextCard/TextCard.tsx
@@ -84,15 +84,17 @@ export const TextCard = ({
           )}
         </div>
       )}
-      <TitleElement className="cc-text-card__title">
-        {type === 'file' ? (
-          parseHtml(title)
-        ) : (
-          <a href={href} className="cc-text-card__link">
-            {parseHtml(title)}
-          </a>
-        )}
-      </TitleElement>
+      {title && (
+        <TitleElement className="cc-text-card__title">
+          {type === 'file' ? (
+            parseHtml(title)
+          ) : (
+            <a href={href} className="cc-text-card__link">
+              {parseHtml(title)}
+            </a>
+          )}
+        </TitleElement>
+      )}
       {type === 'file' && (
         <FileDownload
           className="cc-text-card__file-meta"


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8272.

Makes display of title element conditional on the presence of a title to handle "No results" behaviour without an empty element.