### PR TITLE
8302 feature: adds CTALink component

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -18,6 +18,7 @@
 @import './src/components/Checkbox/checkbox';
 @import './src/components/Contact/contact';
 @import './src/components/CookieMessage/cookie-message';
+@import './src/components/CTALink/cta-link';
 @import './src/components/DateInput/date-input';
 @import './src/components/DescriptionList/description-list';
 @import './src/components/FactCard/fact-card';

--- a/src/components/CTALink/CTALink.stories.tsx
+++ b/src/components/CTALink/CTALink.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text } from '@storybook/addon-knobs';
+
+import CTALink from './CTALink';
+
+const CTALinkExample = () => {
+  const linkText = text('button text', 'Click me');
+  const href = text('href', '/about-us');
+
+  return <CTALink href={href} text={linkText} />;
+};
+
+const stories = storiesOf('CTA Link', module);
+
+stories.add('CTA Link', CTALinkExample);

--- a/src/components/CTALink/CTALink.tsx
+++ b/src/components/CTALink/CTALink.tsx
@@ -1,0 +1,45 @@
+/**
+ * @file CTA Link component; wrapper for Button component with updated styles
+ * and which should only be used when HTML element should be an <a> tag.
+ */
+
+import React from 'react';
+import cx from 'classnames';
+
+import Button from 'Button';
+
+type CTALinkProps = {
+  className?: string;
+  href: string;
+  text: string;
+};
+
+/**
+ * CTALink component; wraps the Button element and always returns
+ * an `<a>` tag with "CTA Link" styles.
+ *
+ * @param {string} className
+ * @param {string} href
+ * @param {string} text
+ *
+ * @returns {ReactElement}
+ */
+export const CTALink = ({ className, href, text }: CTALinkProps) => {
+  const classNames = cx('cc-cta-link', {
+    [className]: className
+  });
+
+  return (
+    <Button
+      className={classNames}
+      href={href}
+      icon="arrowLong"
+      iconPlacementSwitch
+      variant="unstyled"
+    >
+      {text}
+    </Button>
+  );
+};
+
+export default CTALink;

--- a/src/components/CTALink/CTALink.tsx
+++ b/src/components/CTALink/CTALink.tsx
@@ -2,7 +2,6 @@
  * @file CTA Link component; wrapper for Button component with updated styles
  * and which should only be used when HTML element should be an <a> tag.
  */
-
 import React from 'react';
 import cx from 'classnames';
 

--- a/src/components/CTALink/_cta-link.scss
+++ b/src/components/CTALink/_cta-link.scss
@@ -1,0 +1,53 @@
+// ----------------------------------
+// UI Components
+// CTA Link
+// ----------------------------------
+// Design System 1.0 Alpha
+// 2019-11-11
+// ----------------------------------
+
+.cc-cta-link {
+  @extend %anchor-inherit;
+  @include animated-underline(1px);
+
+  align-items: center;
+  color: var(--colour-grey-80);
+  display: inline-flex;
+  line-height: 1.6;
+  margin-right: calc(6 * var(--space-unit));
+  position: relative;
+  text-decoration: none;
+
+  @include hocus {
+    .btn__icon {
+      transform: translate(var(--space-unit), -50%);
+      transition-timing-function: var(--transition-timing-function-in);
+      width: calc(2.5 * var(--space-unit));
+    }
+  }
+
+  &:after {
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: calc(-6 * var(--space-unit));
+    top: 0;
+  }
+
+  .btn__icon {
+    height: 7px;
+    justify-content: flex-end;
+    overflow: hidden;
+    position: absolute;
+    right: calc(-5 * var(--space-unit));
+    top: 50%;
+    transform: translate(0, -50%);
+    transition: all var(--transition-duration) var(--transition-timing-function-out);
+    width: calc(3.75 * var(--space-unit));
+  }
+
+  .btn__icon svg {
+    min-width: calc(3.75 * var(--space-unit));
+  }
+}

--- a/src/components/CTALink/index.ts
+++ b/src/components/CTALink/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CTALink';

--- a/src/components/FactCard/FactCard.tsx
+++ b/src/components/FactCard/FactCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 
-import Button from 'Button';
+import CTALink from 'CTALink';
 import RichText from 'RichText';
 
 type FactCardProps = {
@@ -36,17 +36,7 @@ export const FactCard = ({
           {description}
         </RichText>
       )}
-      {href && linkText && (
-        <Button
-          className="cc-cta-link"
-          href={href}
-          icon="arrowLong"
-          iconPlacementSwitch
-          variant="unstyled"
-        >
-          {linkText}
-        </Button>
-      )}
+      {href && linkText && <CTALink href={href} text={linkText} />}
     </article>
   );
 };

--- a/src/components/FullWidthPromo/FullWidthPromo.tsx
+++ b/src/components/FullWidthPromo/FullWidthPromo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
+import CTALink from 'CTALink';
 import { ImageElement } from 'Image';
-import Button from 'Button';
 import Link from 'Link';
 import RichText from 'RichText';
 import TagList, { TagProps } from 'TagList/TagList';
@@ -93,15 +93,11 @@ export const FullWidthPromo = ({
           </RichText>
         )}
         {linkText?.trim().length > 0 && (
-          <Button
-            className="cc-full-width-promo__link cc-cta-link"
+          <CTALink
+            className="cc-full-width-promo__link"
             href={href}
-            icon="arrowLong"
-            iconPlacementSwitch
-            variant="unstyled"
-          >
-            {linkText}
-          </Button>
+            text={linkText}
+          />
         )}
         {topics && (
           <div className="cc-page-header-compact__topics">

--- a/src/components/FullWidthPromo/_full-width-promo.scss
+++ b/src/components/FullWidthPromo/_full-width-promo.scss
@@ -17,7 +17,7 @@
 .cc-full-width-promo__image {
   @extend %img-cover;
   margin: 0;
-  
+
   @include mq(sm) {
     bottom: 0;
     left: 0;
@@ -32,7 +32,7 @@
   @include grid-container;
   padding-bottom: calc(7.5 * var(--space-unit));
   padding-top: calc(7.5 * var(--space-unit));
-  
+
   @include mq(sm) {
     padding-bottom: calc(9 * var(--space-unit));
     padding-top: calc(9 * var(--space-unit));
@@ -43,7 +43,7 @@
 
 .cc-full-width-promo__content {
   @include grid-column(1, 7);
-  
+
   @include mq(sm) {
     @include grid-column(1, 9);
     background: rgba(255, 255, 255, 0.95);
@@ -119,49 +119,4 @@
 
 .cc-full-width-promo__link {
   margin-bottom: calc(5 * var(--space-unit));
-}
-
-.cc-cta-link {
-  @extend %anchor-inherit;
-  @include animated-underline(1px);
-  align-items: center;
-  color: var(--colour-grey-80);
-  display: inline-flex;
-  line-height: 1.6;
-  margin-right: calc(6 * var(--space-unit));
-  position: relative;
-  text-decoration: none;
-
-  @include hocus {
-    .btn__icon {
-      transform: translate(var(--space-unit), -50%);
-      transition-timing-function: var(--transition-timing-function-in);
-      width: calc(2.5 * var(--space-unit));
-    }
-  }
-
-  &:after {
-    bottom: 0;
-    content: '';
-    left: 0;
-    position: absolute;
-    right: calc(-6 * var(--space-unit));
-    top: 0;
-  }
-
-  .btn__icon {
-    height: 7px;
-    justify-content: flex-end;
-    overflow: hidden;
-    position: absolute;
-    right: calc(-5 * var(--space-unit));
-    top: 50%;
-    transform: translate(0, -50%);
-    transition: all var(--transition-duration) var(--transition-timing-function-out);
-    width: calc(3.75 * var(--space-unit));
-  }
-
-  .btn__icon svg {
-    min-width: calc(3.75 * var(--space-unit));
-  }
 }

--- a/src/components/ImageCardWithCTA/ImageCardWithCTA.tsx
+++ b/src/components/ImageCardWithCTA/ImageCardWithCTA.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 
-import Button from 'Button';
+import CTALink from 'CTALink';
 import { ImageElement } from 'Image';
 import Link from 'Link';
 import RichText from 'RichText';
@@ -73,17 +73,7 @@ export const ImageCardWithCTA = ({
             {description}
           </RichText>
         )}
-        {href && linkText && (
-          <Button
-            className="cc-cta-link"
-            href={href}
-            icon="arrowLong"
-            iconPlacementSwitch
-            variant="unstyled"
-          >
-            {linkText}
-          </Button>
-        )}
+        {href && linkText && <CTALink href={href} text={linkText} />}
       </div>
     </article>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { Button } from 'Button/Button';
 export { default as Checkbox } from 'Checkbox';
 export { Contact } from 'Contact/Contact';
 export { CookieMessage } from 'CookieMessage/CookieMessage';
+export { default as CTALink } from 'CTALink';
 export { default as DateInput } from 'DateInput';
 export { default as DescriptionList } from 'DescriptionList';
 export { default as FactCard } from 'FactCard';


### PR DESCRIPTION
# Description

To avoid repetition in styles I have modularised ("converted to a component") the "CTA Link" style that was previously used only within this repo. It is now being exported to be used by consuming applications, as well as being used by internal components such as FullWidthPromo and FactCard.

This PR makes the necessary changes to modularise CTALink.

See wellcometrust/corporate/issues/8302 for more information.

# To test (locally)

- `git pull {this_branch}`
- `npm run storybook`
- Open "CTA Link"
- Check the styles work as expected
- Open "FactCard"
- Check the styles work as expected
- Open "FillWidthPromo"
- Check the styles work as expected