### PR TITLE
8154 Task: nested accordion

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -40,6 +40,7 @@ export const Accordion = ({
       active: index === active,
       index,
       isEmpty,
+      isNested,
 
       // passes an onClick handler to the child to allow it to set the itself as the active item
       onClick: () => selectItem(index)

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -24,8 +24,8 @@ export const Accordion = ({
   const classNames = cx('cc-accordion', {
     'cc-accordion--has-borders': hasBorders,
     'cc-accordion--empty': isEmpty,
-    'cc-accordion--nested': isNested,
     'cc-accordion--filter': variant === 'filter',
+    'cc-accordion--nested': isNested,
     [className]: className
   });
 

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -7,6 +7,7 @@ type AccordionProps = {
   children?: JSX.Element | JSX.Element[];
   className?: string;
   hasBorders?: boolean;
+  isEmpty?: boolean;
   isNested?: boolean;
 };
 
@@ -14,11 +15,13 @@ export const Accordion = ({
   children,
   className,
   hasBorders,
+  isEmpty,
   isNested
 }: AccordionProps) => {
   const [active, setActive] = useState(-1);
   const classNames = cx('cc-accordion', {
     'cc-accordion--has-borders': hasBorders,
+    'cc-accordion--empty': isEmpty,
     'cc-accordion--nested': isNested,
     [`${className}`]: className
   });
@@ -36,6 +39,7 @@ export const Accordion = ({
       // sets the active item in the accordion
       active: index === active,
       index,
+      isEmpty,
 
       // passes an onClick handler to the child to allow it to set the itself as the active item
       onClick: () => selectItem(index)

--- a/src/components/Accordion/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem.tsx
@@ -7,6 +7,7 @@ export type AccordionItemProps = {
   active?: boolean;
   children?: React.ReactNode;
   index?: number;
+  isEmpty?: boolean;
   onClick?: MouseEventHandler;
   title: string;
   titleActive?: string;
@@ -18,6 +19,7 @@ export const AccordionItem = ({
   active = false,
   children,
   index,
+  isEmpty,
   onClick,
   title,
   titleActive,
@@ -36,30 +38,40 @@ export const AccordionItem = ({
   const TitleElement: any = titleAs || 'h3';
 
   return (
-    <div className={classNames}>
-      <TitleElement className="cc-accordion-item__title">
-        <Button
-          aria-expanded={active}
-          className={buttonClassNames}
-          icon={variant === 'chevron' ? 'chevronRight' : 'closeSmall'}
-          iconPlacementSwitch
-          id={`accordion-button-${index}`}
-          onClick={onClick}
-          variant="unstyled"
-        >
-          {active && titleActive ? titleActive : title}
-        </Button>
-      </TitleElement>
+    <>
+      {isEmpty ? (
+        <div className={classNames}>
+          <TitleElement className="cc-accordion-item__title">
+            <span className={buttonClassNames}>{title}</span>
+          </TitleElement>
+        </div>
+      ) : (
+        <div className={classNames}>
+          <TitleElement className="cc-accordion-item__title">
+            <Button
+              aria-expanded={active}
+              className={buttonClassNames}
+              icon={variant === 'chevron' ? 'chevronRight' : 'closeSmall'}
+              iconPlacementSwitch
+              id={`accordion-button-${index}`}
+              onClick={onClick}
+              variant="unstyled"
+            >
+              {active && titleActive ? titleActive : title}
+            </Button>
+          </TitleElement>
 
-      <div
-        aria-labelledby={`accordion-button-${index}`}
-        className="cc-accordion__content"
-        hidden={!active}
-        ref={content}
-      >
-        {children}
-      </div>
-    </div>
+          <div
+            aria-labelledby={`accordion-button-${index}`}
+            className="cc-accordion__content"
+            hidden={!active}
+            ref={content}
+          >
+            {children}
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/Accordion/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem.tsx
@@ -32,11 +32,11 @@ export const AccordionItem = ({
   const classNames = cx('cc-accordion-item', {
     'cc-accordion-item--active': active
   });
-  const titleClassNames = cx('cc-accordion-item__title', {
-    [`cc-accordion-item__title--nested`]: isNested
-  });
   const buttonClassNames = cx('cc-accordion__button', {
     [`cc-accordion__button--${variant}`]: variant
+  });
+  const textClassNames = cx({
+    'cc-accordion-button__text--nested': isNested
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,13 +46,15 @@ export const AccordionItem = ({
     <>
       {isEmpty ? (
         <div className={classNames}>
-          <TitleElement className={titleClassNames}>
-            <span className={buttonClassNames}>{title}</span>
+          <TitleElement className="cc-accordion-item__title">
+            <div className={buttonClassNames}>
+              <span className={textClassNames}>{title}</span>
+            </div>
           </TitleElement>
         </div>
       ) : (
         <div className={classNames}>
-          <TitleElement className={titleClassNames}>
+          <TitleElement className="cc-accordion-item__title">
             <Button
               aria-expanded={active}
               className={buttonClassNames}
@@ -60,6 +62,7 @@ export const AccordionItem = ({
               iconPlacementSwitch
               id={`accordion-button-${index}`}
               onClick={onClick}
+              textClassName={textClassNames}
               variant="unstyled"
             >
               {active && titleActive ? titleActive : title}

--- a/src/components/Accordion/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem.tsx
@@ -8,6 +8,7 @@ export type AccordionItemProps = {
   children?: React.ReactNode;
   index?: number;
   isEmpty?: boolean;
+  isNested?: boolean;
   onClick?: MouseEventHandler;
   title: string;
   titleActive?: string;
@@ -20,6 +21,7 @@ export const AccordionItem = ({
   children,
   index,
   isEmpty,
+  isNested,
   onClick,
   title,
   titleActive,
@@ -29,6 +31,9 @@ export const AccordionItem = ({
   const content = useRef(null);
   const classNames = cx('cc-accordion-item', {
     'cc-accordion-item--active': active
+  });
+  const titleClassNames = cx('cc-accordion-item__title', {
+    [`cc-accordion-item__title--nested`]: isNested
   });
   const buttonClassNames = cx('cc-accordion__button', {
     [`cc-accordion__button--${variant}`]: variant
@@ -41,13 +46,13 @@ export const AccordionItem = ({
     <>
       {isEmpty ? (
         <div className={classNames}>
-          <TitleElement className="cc-accordion-item__title">
+          <TitleElement className={titleClassNames}>
             <span className={buttonClassNames}>{title}</span>
           </TitleElement>
         </div>
       ) : (
         <div className={classNames}>
-          <TitleElement className="cc-accordion-item__title">
+          <TitleElement className={titleClassNames}>
             <Button
               aria-expanded={active}
               className={buttonClassNames}

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -145,19 +145,18 @@
   }
 }
 
-.cc-accordion-item__title--nested {
+.cc-accordion-button__text--nested {
   padding-left: calc(2 * var(--space-unit));
   position: relative;
 
   &:before {
-    background-color: var(--colour-black);
+    background-color: var(--colour-grey-80);
     content: '';
-    display: block;
-    height: calc(0.75 * var(--space-unit));
+    height: calc(1 * var(--space-unit));
     left: 0;
     position: absolute;
-    top: 19px;
-    width: calc(0.75 * var(--space-unit));
+    top: calc(0.75 * var(--space-unit));
+    width: calc(1 * var(--space-unit));
   }
 }
 

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -137,3 +137,9 @@
     font-weight: bold;
   }
 }
+
+.cc-accordion--empty {
+  .cc-accordion__button--plus {
+    cursor: default;
+  }
+}

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -115,9 +115,12 @@
   transition: transform var(--transition-duration-fast) ease;
 }
 
+// Nested accordion
+
 .cc-accordion--nested {
-  margin-left: calc(2 * var(--space-unit));
+  border-left: 1px solid var(--colour-grey-10);
   margin-top: calc(2 * var(--space-unit));
+  padding-left: var(--space-lg);
 
   & + &,
   &:only-child {
@@ -136,7 +139,29 @@
   .cc-accordion__button--plus[aria-expanded='true'] {
     font-weight: bold;
   }
+
+  .cc-accordion-item--active {
+    padding-bottom: var(--space-md);
+  }
 }
+
+.cc-accordion-item__title--nested {
+  padding-left: calc(2 * var(--space-unit));
+  position: relative;
+
+  &:before {
+    background-color: var(--colour-black);
+    content: '';
+    display: block;
+    height: calc(0.75 * var(--space-unit));
+    left: 0;
+    position: absolute;
+    top: 19px;
+    width: calc(0.75 * var(--space-unit));
+  }
+}
+
+// Empty accordion content
 
 .cc-accordion--empty {
   .cc-accordion__button--plus {


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8154

### Context 

To make it easier for a user to figure out where they are we updated styles for nested accordion.

Design (not fully correct): https://app.zeplin.io/project/5b4e06b48ae4580d4871178a/screen/603538df84f6342c116c1d13

### This PR

- update styles for nested accordion
- add style for empty accordion

![Screenshot 2021-03-11 at 16 58 36](https://user-images.githubusercontent.com/10700103/110825844-62d39d80-828c-11eb-8cdc-4ded4801ed37.png)

### Test

1. git fetch and git checkout this branch `task/8154-nested-accordion`
2. run npm link if needed
3. update NEXT_PUBLIC_API_DOMAIN to`NEXT_PUBLIC_API_DOMAIN=https://wt-corporated8-develop.codeenigma.net` in.env
4. pull https://github.com/wellcometrust/corporate-react/pull/832
5. go to http://localhost:3001/node/5676