### PR TITLE
8315 task(style): generates suite of grid-cell selectors

### DIFF
--- a/src/components/Grid/Cell/_grid-cell.scss
+++ b/src/components/Grid/Cell/_grid-cell.scss
@@ -76,13 +76,6 @@
   }
 }
 
-// custom column widths
-.grid__cell--4-to-12 {
-  @include mq(md) {
-    @include grid-column(4, 13);
-  }
-}
-
 /**
  * Creates a suite of grid selectors to provide granular
  * control over the exact columns a grid cell should

--- a/src/components/Grid/Cell/_grid-cell.scss
+++ b/src/components/Grid/Cell/_grid-cell.scss
@@ -82,3 +82,32 @@
     @include grid-column(4, 13);
   }
 }
+
+/**
+ * Creates a suite of grid selectors to provide granular
+ * control over the exact columns a grid cell should
+ * span, e.g.
+ *
+ * .grid__cell--1-to-2 {
+ *   grid-column-start: 1;
+ *   grid-column-end: 2;
+ * }
+ *
+ * .grid__cell--7-to-13 {
+ *   grid-column-start: 6;
+ *   grid-column-end: 13;
+ * }
+ */
+$columns: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+
+@each $column-start in $columns {
+  @each $column-end in $columns {
+    @if $column-end > $column-start {
+      .grid__cell--#{$column-start}-to-#{$column-end} {
+        @include mq(md) {
+          @include grid-column($column-start, $column-end);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Context

As we update the UI design of our website it is necessary to move away from the strict 3 column grid we are currently using.

# Description

This PR adds more fine-tuned control of grid cells by adding a suite of selectors that will allow a developer to set grid cells to span whatever columns they desire, e.g.

`.grid__cell--1-to-6`
`.grid__cell--1-to-13`
`.grid__cell--6-to-13`

etc.

Once this is released it will be necessary to update the usage of `<GridCell />` in consuming applications to ensure the behaviour of `<GridCell colStart={4} colEnd={12}>` stays the same (12 will need to become 13).

# Test

- `git pull {this_branch}`
- `npm run build`
- `open dist/style.css`
- Open the `dist/style.css` file in your IDE
- Find `grid__cell--1-to-2`
- Inspect selectors/style are as expected