### PR TITLE
8340 bug: update accorrdion's icons

### DIFF
--- a/src/components/Accordion/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem.tsx
@@ -58,7 +58,7 @@ export const AccordionItem = ({
             <Button
               aria-expanded={active}
               className={buttonClassNames}
-              icon={variant === 'chevron' ? 'chevronRight' : 'closeSmall'}
+              icon={variant === 'chevron' ? 'chevron' : 'closeBold'}
               iconPlacementSwitch
               id={`accordion-button-${index}`}
               onClick={onClick}

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -50,9 +50,9 @@
   color: inherit;
 
   .btn__icon {
-    height: 1.5rem;
+    height: 0.5rem;
     position: relative;
-    width: 1.5rem;
+    width: 0.5rem;
   }
 
   .btn__icon--right {
@@ -106,8 +106,8 @@
   }
 }
 
-.cc-accordion__button--chevron svg {
-  transform: rotate(-90deg);
+.cc-accordion__button--chevron[aria-expanded='true'] svg {
+  transform: rotate(90deg);
 }
 
 .cc-accordion__button--plus[aria-expanded='false'] svg {

--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -65,7 +65,7 @@ export const SidebarFilter = ({
           {activeTags.map(({ label, value }) => (
             <Button
               className="cc-sidebar-filter__tags-list-item"
-              icon="closeSmall"
+              icon="closeBold"
               iconPlacementSwitch
               key={value}
               onClick={() => onTagRemove(value)}

--- a/src/components/SidebarFilter/_sidebar-filter.scss
+++ b/src/components/SidebarFilter/_sidebar-filter.scss
@@ -47,8 +47,8 @@
   }
 
   .btn__icon {
-    height: 1.5rem;
-    width: 1.5rem;
+    height: 0.5rem;
+    width: 0.5rem;
   }
 }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8340 and https://github.com/wellcometrust/corporate/issues/8325

### This PR

- updates accordion's icons -> https://github.com/wellcometrust/corporate/issues/8340
- fixes displaying issue in Safari -> https://github.com/wellcometrust/corporate/issues/8325

### Test

- pull this branch
- open http://localhost:3001/grant-funding/schemes/wellcome-career-development-awards#scheme-at-a-glance-3f5f in Safari
- scroll to accordion -> see icons 
- check on smaller screens (mobile) -> on this page component has icon
