### PR TITLE
8346 bug: fix page title margin

### DIFF
--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -51,37 +51,41 @@ export const PageHeader = ({
             <div className="cc-page-header__main">
               <PageTitle meta={meta} metaLabel={metaLabel} title={title} />
             </div>
-            <div className="cc-page-header__tools">
-              {/* TODO: Add breadcrumb here
+            {(datePublished || dateUpdated || share) && (
+              <div className="cc-page-header__tools">
+                {/* TODO: Add breadcrumb here
             <div className="cc-page-header__breadcrumb">Breadcrumb</div> */}
-              {(datePublished || dateUpdated) && (
-                <dl className="cc-page-header__dates">
-                  {datePublished && (
-                    <>
-                      <dt className="cc-page-header__date-label">Published</dt>
-                      <dd className="cc-page-header__date">
-                        <time>
-                          <FormattedDate dateString={datePublished} />
-                        </time>
-                      </dd>
-                    </>
-                  )}
-                  {dateUpdated && (
-                    <>
-                      <dt className="cc-page-header__date-label">
-                        Last updated
-                      </dt>
-                      <dd className="cc-page-header__date">
-                        <time>
-                          <FormattedDate dateString={dateUpdated} />
-                        </time>
-                      </dd>
-                    </>
-                  )}
-                </dl>
-              )}
-              <div className="cc-page-header__share">{share}</div>
-            </div>
+                {(datePublished || dateUpdated) && (
+                  <dl className="cc-page-header__dates">
+                    {datePublished && (
+                      <>
+                        <dt className="cc-page-header__date-label">
+                          Published
+                        </dt>
+                        <dd className="cc-page-header__date">
+                          <time>
+                            <FormattedDate dateString={datePublished} />
+                          </time>
+                        </dd>
+                      </>
+                    )}
+                    {dateUpdated && (
+                      <>
+                        <dt className="cc-page-header__date-label">
+                          Last updated
+                        </dt>
+                        <dd className="cc-page-header__date">
+                          <time>
+                            <FormattedDate dateString={dateUpdated} />
+                          </time>
+                        </dd>
+                      </>
+                    )}
+                  </dl>
+                )}
+                {share && <div className="cc-page-header__share">{share}</div>}
+              </div>
+            )}
           </Grid>
         </div>
         {imageLocation === 'bottom' && imageElement}

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -37,18 +37,23 @@ export const PageHeader = ({
   standfirst,
   title
 }: PageHeaderProps) => {
-  const classNames = cx('cc-page-header', {
-    [`cc-page-header--${background}`]: background,
-    [`${className}`]: className
-  });
+  const classNames = {
+    header: cx('cc-page-header', {
+      [`cc-page-header--${background}`]: background,
+      [`${className}`]: className
+    }),
+    headerMain: cx('cc-page-header__main', {
+      'cc-page-header__main--title-only': !(standfirst || children)
+    })
+  };
 
   return (
     !hideHeaderContent && (
-      <div className={classNames}>
+      <div className={classNames.header}>
         {imageLocation === 'top' && imageElement}
         <div className="cc-page-header__container">
           <Grid>
-            <div className="cc-page-header__main">
+            <div className={classNames.headerMain}>
               <PageTitle meta={meta} metaLabel={metaLabel} title={title} />
             </div>
             {(datePublished || dateUpdated || share) && (
@@ -89,14 +94,16 @@ export const PageHeader = ({
           </Grid>
         </div>
         {imageLocation === 'bottom' && imageElement}
-        <Grid>
-          {standfirst && (
-            <div className="cc-page-header__standfirst">
-              <RichText>{standfirst}</RichText>
-            </div>
-          )}
-          {children && <div className="cc-page-header__misc">{children}</div>}
-        </Grid>
+        {(standfirst || children) && (
+          <Grid>
+            {standfirst && (
+              <div className="cc-page-header__standfirst">
+                <RichText>{standfirst}</RichText>
+              </div>
+            )}
+            {children && <div className="cc-page-header__misc">{children}</div>}
+          </Grid>
+        )}
       </div>
     )
   );

--- a/src/components/PageHeader/_page-header.scss
+++ b/src/components/PageHeader/_page-header.scss
@@ -76,7 +76,7 @@
 
 .cc-page-header__main {
   @include grid-column(1, 7);
-  margin-bottom: var(--space-xl);
+  margin-bottom: var(--space-lg);
 
   @include mq(sm) {
     @include grid-column(1, 13);

--- a/src/components/PageHeader/_page-header.scss
+++ b/src/components/PageHeader/_page-header.scss
@@ -73,14 +73,13 @@
   }
 }
 
-
 .cc-page-header__main {
   @include grid-column(1, 7);
-  
+
   @include mq(sm) {
     @include grid-column(1, 13);
   }
-  
+
   @include mq(md) {
     @include grid-column(4, 10);
   }

--- a/src/components/PageHeader/_page-header.scss
+++ b/src/components/PageHeader/_page-header.scss
@@ -76,15 +76,18 @@
 
 .cc-page-header__main {
   @include grid-column(1, 7);
-  margin-bottom: var(--space-lg);
-
+  
   @include mq(sm) {
     @include grid-column(1, 13);
   }
-
+  
   @include mq(md) {
     @include grid-column(4, 10);
   }
+}
+
+.cc-page-header__main--title-only {
+  margin-bottom: var(--space-lg);
 }
 
 .cc-page-header__tools {

--- a/src/components/PageTitle/_page-title.scss
+++ b/src/components/PageTitle/_page-title.scss
@@ -12,7 +12,6 @@
   @include heading-divider;
 
   font-family: var(--font-secondary);
-  margin-bottom: 0;
   text-align: center;
 }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8346 and https://github.com/wellcometrust/corporate/issues/8015

### Context

I was asked to reduce the margin-bottom of the page title site-wide. I wasn't aware that news articles have a different header.
I removed the margin-bottom for `.cc-page-title` and the result was an odd-looking news page. We want the total margin-bottom of the page title on desktop to be 64px.

### This PR

- adds margin-bottom to `cc-page-title` (32px on desktop)
- reduces `cc-page-header__main` margin-bottom to 32px on desktop
- adds check to prevent showing an empty markup for `cc-page-header__tools` - https://github.com/wellcometrust/corporate/issues/8015

### Test
- pull this branch
- see: http://localhost:3001/grant-funding (total of 64px margin bottom, no empty `cc-page-header__tools` markup)
- see: http://localhost:3001/news/why-we-need-fair-global-vaccine-allocation-end-covid-19 (32px margin-bottom)
- see: http://localhost:3001/grant-funding/schemes/masters-studentships-humanities-and-social-science (total of 64px margin bottom, with`cc-page-header__tools` markup)