### PR TITLE
8346 bug(style): Page header margins

### DIFF
--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -37,18 +37,23 @@ export const PageHeader = ({
   standfirst,
   title
 }: PageHeaderProps) => {
-  const classNames = cx('cc-page-header', {
-    [`cc-page-header--${background}`]: background,
-    [`${className}`]: className
-  });
+  const classNames = {
+    header: cx('cc-page-header', {
+      [`cc-page-header--${background}`]: background,
+      [`${className}`]: className
+    }),
+    headerMain: cx('cc-page-header__main', {
+      'cc-page-header__main--title-only': !(standfirst || children)
+    })
+  };
 
   return (
     !hideHeaderContent && (
-      <div className={classNames}>
+      <div className={classNames.header}>
         {imageLocation === 'top' && imageElement}
         <div className="cc-page-header__container">
           <Grid>
-            <div className="cc-page-header__main">
+            <div className={classNames.headerMain}>
               <PageTitle meta={meta} metaLabel={metaLabel} title={title} />
             </div>
             {(datePublished || dateUpdated || share) && (
@@ -89,14 +94,16 @@ export const PageHeader = ({
           </Grid>
         </div>
         {imageLocation === 'bottom' && imageElement}
-        <Grid>
-          {standfirst && (
-            <div className="cc-page-header__standfirst">
-              <RichText>{standfirst}</RichText>
-            </div>
-          )}
-          {children && <div className="cc-page-header__misc">{children}</div>}
-        </Grid>
+        {(standfirst || children) && (
+          <Grid>
+            {standfirst && (
+              <div className="cc-page-header__standfirst">
+                <RichText>{standfirst}</RichText>
+              </div>
+            )}
+            {children && <div className="cc-page-header__misc">{children}</div>}
+          </Grid>
+        )}
       </div>
     )
   );

--- a/src/components/PageHeader/_page-header.scss
+++ b/src/components/PageHeader/_page-header.scss
@@ -76,15 +76,18 @@
 
 .cc-page-header__main {
   @include grid-column(1, 7);
-  margin-bottom: var(--space-lg);
-
+  
   @include mq(sm) {
     @include grid-column(1, 13);
   }
-
+  
   @include mq(md) {
     @include grid-column(4, 10);
   }
+}
+
+.cc-page-header__main--title-only {
+  margin-bottom: var(--space-lg);
 }
 
 .cc-page-header__tools {


### PR DESCRIPTION
Also relates to wellcometrust/corporate#8119

Additional fix made to correct bottom margin for title block when no standfirst is present.