### PR TITLE
8344 bug(style): Safari hack added to force sticky elements to respect z-index

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,3 +1,9 @@
+/**
+ * @deprecated Footer and all non-generic child components are to be moved
+ * to corporate-react
+ *
+ * @see {@link https://github.com/wellcometrust/corporate/issues/8352}
+ */
 import React from 'react';
 
 import FooterSocial from './FooterSocial/FooterSocial';

--- a/src/components/Footer/_footer.scss
+++ b/src/components/Footer/_footer.scss
@@ -10,6 +10,12 @@
   background: var(--X-colour-dark-blue);
   color: var(--colour-white);
   position: relative;
+
+  /**
+   * Inpage nav fix
+   * forces position: sticky elements in safari to respect z-index
+   */
+  transform: translate3d(0, 0, 0);
   z-index: var(--z-low);
 }
 

--- a/src/components/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/NewsletterForm/NewsletterForm.tsx
@@ -1,3 +1,9 @@
+/**
+ * @deprecated NewsletterForm and all non-generic child components are to be
+ * moved to corporate-react
+ *
+ * @see {@link https://github.com/wellcometrust/corporate/issues/8353}
+ */
 import React, { useState } from 'react';
 import cx from 'classnames';
 

--- a/src/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup/NewsletterSignup.tsx
@@ -1,3 +1,8 @@
+/**
+ * @deprecated NewsletterSignup is to be moved to corporate-react
+ *
+ * @see {@link https://github.com/wellcometrust/corporate/issues/8353}
+ */
 import React from 'react';
 
 import Grid, { GridCell } from 'Grid';

--- a/src/components/NewsletterSignup/_newsletter-signup.scss
+++ b/src/components/NewsletterSignup/_newsletter-signup.scss
@@ -12,6 +12,12 @@
   padding-bottom: var(--space-xl);
   padding-top: var(--space-xl);
   position: relative;
+
+  /**
+   * Inpage nav fix
+   * forces position: sticky elements in safari to respect z-index
+   */
+  transform: translate3d(0, 0, 0);
   z-index: var(--z-low);
 
   // WYSIWYG content styles


### PR DESCRIPTION
## Context
These style hacks have been added to force sticky elements in Safari (namely in-page nav) to respect z-index.

I've stopped short of creating utility classes and mixins for use in corporate-components since I believe the proper place for NewsletterSignup and Footer is in corporate-react. Deprecation notices added to those components are in this PR.

Companion PR https://github.com/wellcometrust/corporate-react/pull/859