### PR TITLE
8364 task: accessible input error

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -32,6 +32,7 @@
 @import './src/components/FormField/form-field';
 @import './src/components/FormFieldError/form-field-error';
 @import './src/components/FormFieldHint/form-field-hint';
+@import './src/components/FormFieldset/form-fieldset';
 @import './src/components/FormSelect/form-select';
 @import './src/components/FullWidthPromo/full-width-promo';
 @import './src/components/Gallery/gallery';

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -23,6 +23,7 @@ export const DateInput = forwardRef(
     return (
       <input
         aria-describedby={describedBy}
+        aria-invalid={isInvalid}
         className={classNames}
         id={id}
         name={name}

--- a/src/components/FormFieldset/FormFieldset.tsx
+++ b/src/components/FormFieldset/FormFieldset.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import cx from 'classnames';
+
+type FormFieldProps = {
+  children: JSX.Element[] | JSX.Element;
+  className?: string;
+  legend: string;
+};
+
+export const FormFieldset = ({
+  children,
+  className,
+  legend
+}: FormFieldProps) => {
+  const classNames = cx('cc-form-fieldset', {
+    [className]: className
+  });
+
+  return (
+    <fieldset className={classNames}>
+      <legend className="cc-form-legend">{legend}</legend>
+      {children}
+    </fieldset>
+  );
+};
+
+export default FormFieldset;

--- a/src/components/FormFieldset/_form-fieldset.scss
+++ b/src/components/FormFieldset/_form-fieldset.scss
@@ -1,0 +1,19 @@
+// ----------------------------------
+// UI Components
+// FormFieldset
+// ----------------------------------
+// Design System 1.0 Alpha
+// 2019-11-11
+// ----------------------------------
+
+.cc-form-fieldset {
+  border: 0;
+  margin: 0 0 var(--space-lg) 0;
+  padding: 0;
+}
+
+.cc-form-legend {
+  color: var(--colour-grey-80);
+  display: block;
+  margin-bottom: var(--space-xs);
+}

--- a/src/components/FormFieldset/index.ts
+++ b/src/components/FormFieldset/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FormFieldset';

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -23,6 +23,7 @@ export const TextArea = forwardRef(
     return (
       <textarea
         aria-describedby={describedBy}
+        aria-invalid={isInvalid}
         className={classNames}
         id={id}
         name={name}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -33,6 +33,7 @@ export const TextInput = forwardRef(
     return (
       <input
         aria-describedby={describedBy}
+        aria-invalid={isInvalid}
         className={classNames}
         id={id}
         name={name}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export { FormattedDate } from 'FormattedDate/FormattedDate';
 export { default as FormField } from 'FormField';
 export { default as FormFieldError } from 'FormFieldError';
 export { default as FormFieldHint } from 'FormFieldHint';
+export { default as FormFieldset } from 'FormFieldset';
 export { default as FormSelect } from 'FormSelect';
 export { default as FullWidthPromo } from 'FullWidthPromo';
 export { Gallery, GalleryMedia } from 'Gallery/Gallery';


### PR DESCRIPTION
https://github.com/wellcometrust/corporate/issues/8364

### Context

I was reading about making forms more accessible to screen readers and this is the first attempt to improve our forms.

We should add **aria-invalid** to input and textarea.

 **aria-invalid** is used:

- when the value entered into an input field does not conform to the format expected by the application,
- to indicate that a required field has not been filled in.

see: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute

We need to make the radio buttons group more understandable for all users, as related controls are easier to identify (I added `FormFiledset` component).

see: https://www.w3.org/WAI/tutorials/forms/grouping/


### This PR

- adds `aria-invalid` to the input and text area components
- add `FormFieldset` component


### Examples

1. Required field now has an indication of it (`invalid data`)

![Screenshot 2021-03-19 at 17 30 32](https://user-images.githubusercontent.com/10700103/111979930-92d93700-8afd-11eb-853d-f9d916bf0d14.png)

2. Radio buttons group now provides a context for the radio button

<img width="651" alt="Screenshot 2021-03-19 at 18 28 28" src="https://user-images.githubusercontent.com/10700103/111980597-6f62bc00-8afe-11eb-9238-d4f59e9cf7d2.png">


