### PR TITLE
7462 bug: Infobox child item margins

### DIFF
--- a/src/assets/styles/40-objects/_app.scss
+++ b/src/assets/styles/40-objects/_app.scss
@@ -1,3 +1,8 @@
+/**
+ * @deprecated contents moved to corporate-react
+ * to be removed at earliest opportunity
+ */
+
 // ----------------------------------
 // UI Settings
 // Global

--- a/src/components/Contact/_contact.scss
+++ b/src/components/Contact/_contact.scss
@@ -15,6 +15,11 @@
   padding: var(--space-lg) 0;
 }
 
+// ensure space is added between a contact and the next item
+.cc-contact + :not(.cc-contact) {
+  margin-top: var(--space-unit);
+}
+
 .cc-contact--nested {
   border: 0;
   padding-bottom: var(--space-sm);

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -109,6 +109,10 @@
   }
 }
 
+.cc-text-snippet > :last-child {
+  margin-bottom: 0;
+}
+
 .cc-rich-text-snippet {
   @extend %body-large;
   line-height: var(--body-line-height-sm);

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -103,14 +103,6 @@
   td {
     font-size: var(--body-md);
   }
-
-  > :last-child {
-    margin-bottom: 0;
-  }
-}
-
-.cc-text-snippet > :last-child {
-  margin-bottom: 0;
 }
 
 .cc-rich-text-snippet {
@@ -125,10 +117,6 @@
   ul {
     @extend %list-base;
     margin-bottom: calc(2 * var(--space-unit));
-  }
-
-  > :last-child {
-    margin-bottom: 0;
   }
 }
 
@@ -148,4 +136,11 @@
 .cc-rich-text__table-wrap {
   overflow-x: auto;
   width: 100%;
+}
+
+// remove any bottom margins
+.cc-text-snippet > :last-child,
+.cc-rich-text > :last-child,
+.cc-rich-text-snippet > :last-child {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
Relates to:
- wellcometrust/corporate#7462
- wellcometrust/corporate#8266

This PR fixes two issues to do with bottom margins:
* Removes the bottom margin from the last child element of a text snippet (a wrapper for content used within an info box)
* Ensures there is space between a Contact and any following element which isn't another Contact. Contacts are not styled like list elements such as cards because they are effectively standalone items and are designed to butt up against one another.