### PR TITLE
8377 task: rename isRequired prop to required for form elements

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,10 +11,10 @@ type CheckboxProps = {
   disabled?: boolean;
   id: string;
   isInvalid?: boolean;
-  isRequired?: boolean;
   label: string;
   name?: string;
   onChange?: () => void;
+  required?: boolean;
   value?: string;
 };
 
@@ -27,10 +27,10 @@ export const Checkbox = forwardRef(
       disabled,
       id,
       isInvalid,
-      isRequired,
       label,
       name,
       onChange,
+      required,
       value
     }: CheckboxProps,
     ref: React.Ref<HTMLInputElement>
@@ -51,7 +51,7 @@ export const Checkbox = forwardRef(
           onChange={onChange}
           name={name}
           ref={ref}
-          required={isRequired}
+          required={required}
           type="checkbox"
           value={value}
         />

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -6,13 +6,13 @@ type DateInputProps = {
   describedBy?: string;
   id: string;
   isInvalid?: boolean;
-  isRequired?: boolean;
   name: string;
+  required?: boolean;
 };
 
 export const DateInput = forwardRef(
   (
-    { className, describedBy, id, isInvalid, isRequired, name }: DateInputProps,
+    { className, describedBy, id, isInvalid, name, required }: DateInputProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
     const classNames = cx('cc-date-input', {
@@ -28,7 +28,7 @@ export const DateInput = forwardRef(
         id={id}
         name={name}
         ref={ref}
-        required={isRequired}
+        required={required}
         type="date"
       />
     );

--- a/src/components/FormSelect/FormSelect.tsx
+++ b/src/components/FormSelect/FormSelect.tsx
@@ -5,9 +5,9 @@ type FormSelectProps = {
   className?: string;
   defaultText?: string;
   id: string;
-  isRequired?: boolean;
   name: string;
   options: string[];
+  required?: boolean;
 };
 
 export const FormSelect = forwardRef(
@@ -16,9 +16,9 @@ export const FormSelect = forwardRef(
       className,
       defaultText = 'Please select',
       id,
-      isRequired,
       name,
-      options
+      options,
+      required
     }: FormSelectProps,
     ref: React.Ref<HTMLSelectElement>
   ) => {
@@ -33,7 +33,7 @@ export const FormSelect = forwardRef(
         id={id}
         name={name}
         ref={ref}
-        required={isRequired}
+        required={required}
       >
         <option disabled value="">
           {defaultText}

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -8,9 +8,9 @@ type RadioInputProps = {
   describedBy?: string;
   id: string;
   isInvalid?: boolean;
-  isRequired?: boolean;
   label?: string;
   name: string;
+  required?: boolean;
   value: string;
 };
 
@@ -21,9 +21,9 @@ export const RadioInput = forwardRef(
       describedBy,
       id,
       isInvalid,
-      isRequired,
       label,
       name,
+      required,
       value
     }: RadioInputProps,
     ref: React.Ref<HTMLInputElement>
@@ -41,7 +41,7 @@ export const RadioInput = forwardRef(
           id={id}
           name={name}
           ref={ref}
-          required={isRequired}
+          required={required}
           type="radio"
           value={value}
         />
@@ -54,7 +54,7 @@ export const RadioInput = forwardRef(
         id={id}
         name={name}
         ref={ref}
-        required={isRequired}
+        required={required}
         type="radio"
         value={value}
       />

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -6,13 +6,13 @@ type TextAreaProps = {
   describedBy?: string;
   id: string;
   isInvalid?: boolean;
-  isRequired?: boolean;
   name: string;
+  required?: boolean;
 };
 
 export const TextArea = forwardRef(
   (
-    { className, describedBy, id, isInvalid, isRequired, name }: TextAreaProps,
+    { className, describedBy, id, isInvalid, name, required }: TextAreaProps,
     ref: React.Ref<HTMLTextAreaElement>
   ) => {
     const classNames = cx('cc-textarea', {
@@ -28,7 +28,7 @@ export const TextArea = forwardRef(
         id={id}
         name={name}
         ref={ref}
-        required={isRequired}
+        required={required}
       />
     );
   }

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -6,8 +6,8 @@ type TextInputProps = {
   describedBy?: string;
   id: string;
   isInvalid?: boolean;
-  isRequired?: boolean;
   name: string;
+  required?: boolean;
   type: 'text' | 'email' | 'tel';
 };
 
@@ -18,8 +18,8 @@ export const TextInput = forwardRef(
       describedBy,
       id,
       isInvalid,
-      isRequired,
       name,
+      required,
       type = 'text'
     }: TextInputProps,
     ref: React.Ref<HTMLInputElement>
@@ -38,7 +38,7 @@ export const TextInput = forwardRef(
         id={id}
         name={name}
         ref={ref}
-        required={isRequired}
+        required={required}
         type={type}
       />
     );


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8377

As discussed here https://github.com/wellcometrust/corporate-components/pull/451#discussion_r5994833, we are changing the required prop name for the form components.

### This PR

- changes `isRequired` prop name to `required`

