### PR TITLE
8363 task: add input date fallback for Safari

### DIFF
--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -9,6 +9,7 @@ type DateInputProps = {
   isInvalid?: boolean;
   isRequired?: boolean;
   name: string;
+  pattern?: string;
 };
 
 export const DateInput = forwardRef(
@@ -20,7 +21,8 @@ export const DateInput = forwardRef(
       isDisabled,
       isInvalid,
       isRequired,
-      name
+      name,
+      pattern
     }: DateInputProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
@@ -37,6 +39,7 @@ export const DateInput = forwardRef(
         disabled={isDisabled}
         id={id}
         name={name}
+        pattern={pattern}
         ref={ref}
         required={isRequired}
         type="date"

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -9,6 +9,7 @@ type TextInputProps = {
   isInvalid?: boolean;
   isRequired?: boolean;
   name: string;
+  pattern?: string;
   type: 'text' | 'email' | 'tel';
 };
 
@@ -22,6 +23,7 @@ export const TextInput = forwardRef(
       isInvalid,
       isRequired,
       name,
+      pattern,
       type = 'text'
     }: TextInputProps,
     ref: React.Ref<HTMLInputElement>
@@ -40,6 +42,7 @@ export const TextInput = forwardRef(
         disabled={isDisabled}
         id={id}
         name={name}
+        pattern={pattern}
         ref={ref}
         required={isRequired}
         type={type}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -5,6 +5,7 @@ type TextInputProps = {
   className?: string;
   describedBy?: string;
   id: string;
+  inputMode?: 'numeric' | 'decimal';
   isDisabled?: boolean;
   isInvalid?: boolean;
   isRequired?: boolean;
@@ -19,6 +20,7 @@ export const TextInput = forwardRef(
       className,
       describedBy,
       id,
+      inputMode,
       isDisabled,
       isInvalid,
       isRequired,
@@ -41,6 +43,7 @@ export const TextInput = forwardRef(
         className={classNames}
         disabled={isDisabled}
         id={id}
+        inputMode={inputMode}
         name={name}
         pattern={pattern}
         ref={ref}


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8363

### Context

1. `<input type="date">` is not supported in Safari. 

- unsupporting browsers gracefully degrade to a text input
- with date input supported, the value is normalized to the format `yyyy-mm-dd`, but with a text input, the browser has no recognition of what format the date should be in

One way around this is the `pattern` attribute on your date input. Even though the date picker doesn't use it, the text input fallback will.

see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date

2. Instead of using `<input type="number">` we should use `<input type="text" inputmode="numeric" pattern="[0-9]*">` (this is following the gov.uk guidance)

see: https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/

### This PR

- adds `pattern` prop to `DateInput` and `TextInput`
- adds `inputMode` to `TextInput`