### PR TITLE
8371 task: add props and style for legend

### DIFF
--- a/src/components/FormFieldset/FormFieldset.tsx
+++ b/src/components/FormFieldset/FormFieldset.tsx
@@ -16,18 +16,19 @@ export const FormFieldset = ({
   legend,
   legendClassName
 }: FormFieldProps) => {
-  const classNames = cx('cc-form-fieldset', {
-    [className]: className
-  });
-
-  const legendClassNames = cx('cc-form-legend', {
-    'is-disabled': isDisabled,
-    [legendClassName]: legendClassName
-  });
+  const classNames = {
+    fieldset: cx('cc-form-fieldset', {
+      [className]: className
+    }),
+    legend: cx('cc-form-legend', {
+      'is-disabled': isDisabled,
+      [legendClassName]: legendClassName
+    })
+  };
 
   return (
-    <fieldset className={classNames}>
-      <legend className={legendClassNames}>{legend}</legend>
+    <fieldset className={classNames.fieldset}>
+      <legend className={classNames.legend}>{legend}</legend>
       {children}
     </fieldset>
   );

--- a/src/components/FormFieldset/FormFieldset.tsx
+++ b/src/components/FormFieldset/FormFieldset.tsx
@@ -4,21 +4,30 @@ import cx from 'classnames';
 type FormFieldProps = {
   children: JSX.Element[] | JSX.Element;
   className?: string;
+  isDisabled?: boolean;
   legend: string;
+  legendClassName?: string;
 };
 
 export const FormFieldset = ({
   children,
   className,
-  legend
+  isDisabled,
+  legend,
+  legendClassName
 }: FormFieldProps) => {
   const classNames = cx('cc-form-fieldset', {
     [className]: className
   });
 
+  const legendClassNames = cx('cc-form-legend', {
+    'is-disabled': isDisabled,
+    [legendClassName]: legendClassName
+  });
+
   return (
     <fieldset className={classNames}>
-      <legend className="cc-form-legend">{legend}</legend>
+      <legend className={legendClassNames}>{legend}</legend>
       {children}
     </fieldset>
   );

--- a/src/components/FormFieldset/_form-fieldset.scss
+++ b/src/components/FormFieldset/_form-fieldset.scss
@@ -17,3 +17,7 @@
   display: block;
   margin-bottom: var(--space-xs);
 }
+
+.cc-form-legend.is-disabled {
+  color: var(--colour-grey-60);
+}


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8371

### Context

To group a group of inputs (e.g radio buttons) correctly and give more context for screen reader users, we should wrap that group in a fieldset with legend.

Our design requires changing the colour of a label when input is disabled.

### This PR

- adds `isDisabled` and `legendClassName` props to legend

