### PR TITLE
8395 task(style): change the colour for H4 within accordion

### DIFF
--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -34,6 +34,13 @@
     font-size: var(--heading-sm);
   }
 
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: var(--colour-grey-70);
+  }
+
   .cc-accordion + *,
   .cc-rich-text + * {
     margin-top: calc(2 * var(--space-sm));

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -34,10 +34,7 @@
     font-size: var(--heading-sm);
   }
 
-  h3,
-  h4,
-  h5,
-  h6 {
+  h4 {
     color: var(--colour-grey-70);
   }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8395

### Context

This is an alternative to changing the font size for H4 within accordion which is mentioned in [this ticket](https://github.com/wellcometrust/corporate/issues/8290).

### This PR

- changes the colour of h4 within accordion to grey #5c5c5c

### Updated styles

![Screenshot 2021-04-08 at 11 35 09](https://user-images.githubusercontent.com/10700103/114012880-cab2df00-985e-11eb-91ab-c6479b99f0f4.png)

