### PR TITLE
8397 task: add NumberInput

### DIFF
--- a/src/components/NumberInput/NumberInput.md
+++ b/src/components/NumberInput/NumberInput.md
@@ -1,0 +1,14 @@
+# NumberInput
+
+Component to use when asking for a whole number.
+
+## When to use
+
+NumberInput can be used multiple times within a form.
+
+## When NOT to use
+
+Don't use NumberInput when asking for decimal numbers.
+If you're asking the user to enter a number that might include decimal places, use **input type="text" without inputmode or pattern attributes**.
+
+_source: https://design-system.service.gov.uk/components/text-input/_

--- a/src/components/NumberInput/NumberInput.stories.tsx
+++ b/src/components/NumberInput/NumberInput.stories.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import NumberInput from 'NumberInput';
+import Label from 'Label';
+import FormField from 'FormField';
+import FormFieldHint from 'FormFieldHint';
+import FormFieldError from 'FormFieldError';
+import Readme from './NumberInput.md';
+
+const NumberInputExample = () => {
+  const error = text('Error text', 'Error');
+  const hint = text('Hint text', 'Hint');
+  const label = text('Label text', 'Label');
+  const isDisabled = boolean('Is disabled?', false);
+  const isRequired = boolean('Is required?', false);
+  const hasError = boolean('Has error?', false);
+
+  return (
+    <FormField>
+      <Label htmlFor="numberExample" isDisabled={isDisabled} text={label} />
+      <NumberInput
+        describedBy={
+          hasError
+            ? 'numberExampleError numberExampleHint'
+            : 'numberExampleHint'
+        }
+        isDisabled={isDisabled}
+        isInvalid={hasError}
+        isRequired={isRequired}
+        id="numberExample"
+        name="numberExample"
+      />
+      <FormFieldHint id="numberExampleHint">
+        <p>{hint}</p>
+      </FormFieldHint>
+      {(hasError || isRequired) && (
+        <FormFieldError id="numberExampleError" errors={error} />
+      )}
+    </FormField>
+  );
+};
+
+const stories = storiesOf('NumberInput', module);
+
+stories.add('NumberInput', NumberInputExample, {
+  readme: { sidebar: Readme }
+});

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -1,0 +1,45 @@
+import React, { forwardRef } from 'react';
+import TextInput from 'TextInput';
+
+type NumberInputProps = {
+  className?: string;
+  describedBy?: string;
+  id: string;
+  isDisabled?: boolean;
+  isInvalid?: boolean;
+  isRequired?: boolean;
+  name: string;
+};
+
+export const NumberInput = forwardRef(
+  (
+    {
+      className,
+      describedBy,
+      id,
+      isDisabled,
+      isInvalid,
+      isRequired,
+      name
+    }: NumberInputProps,
+    ref: React.Ref<HTMLInputElement>
+  ) => {
+    return (
+      <TextInput
+        className={className}
+        describedBy={describedBy}
+        id={id}
+        inputMode="numeric"
+        isDisabled={isDisabled}
+        isInvalid={isInvalid}
+        isRequired={isRequired}
+        name={name}
+        pattern="[0-9]*"
+        ref={ref}
+        type="text"
+      />
+    );
+  }
+);
+
+export default NumberInput;

--- a/src/components/NumberInput/index.ts
+++ b/src/components/NumberInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NumberInput';

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -5,7 +5,7 @@ type TextInputProps = {
   className?: string;
   describedBy?: string;
   id: string;
-  inputMode?: 'numeric' | 'decimal';
+  inputMode?: 'numeric';
   isDisabled?: boolean;
   isInvalid?: boolean;
   isRequired?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export { default as ImageCard } from 'ImageCard';
 export { default as ImageCardWithCTA } from 'ImageCardWithCTA';
 export { NewsletterSignup } from 'NewsletterSignup/NewsletterSignup';
 export { NewsletterForm } from 'NewsletterForm/NewsletterForm';
+export { default as NumberInput } from 'NumberInput';
 export { Quote } from 'Quote/Quote';
 export { PageHeader } from 'PageHeader/PageHeader';
 export { default as PageHeaderCompact } from 'PageHeaderCompact';


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8397

### Context

I extended `TextInput` component to accept `pattern` and `inputmode` props to create an accessible number input field. But when I was building a form with a number field I forgot what props I need to add.

> **Numbers**
> Asking for whole numbers
> If you're asking the user to enter a whole number and you want to bring up the numeric keypad on a mobile device, set the inputmode attribute to numeric and the pattern attribute to [0-9]*.

_source: https://design-system.service.gov.uk/components/text-input/_

### This PR

- adds `NumberInput` component