### PR TITLE
8383 task(style): updates various styles in various Card components

### DIFF
--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -55,14 +55,6 @@
   display: flex;
   flex-wrap: wrap;
   margin-bottom: calc(2 * var(--space-unit));
-
-  @include mq(sm) {
-    margin-bottom: calc(1.5 * var(--space-unit));
-  }
-
-  @include mq(md) {
-    margin-bottom: calc(3 * var(--space-unit));
-  }
 }
 
 .cc-featured-promo__meta-item {
@@ -122,7 +114,11 @@
 
 .cc-featured-promo__link {
   @extend %anchor-inherit;
+  @extend %heading-large;
   @include animated-underline;
+
+  font-weight: normal;
+  line-height: 1.7;
 
   /**
    * Imitate the hover state when a user hovers over the image of

--- a/src/components/FullWidthPromo/_full-width-promo.scss
+++ b/src/components/FullWidthPromo/_full-width-promo.scss
@@ -30,8 +30,8 @@
 
 .cc-full-width-promo__container {
   @include grid-container;
-  padding-bottom: calc(7.5 * var(--space-unit));
-  padding-top: calc(7.5 * var(--space-unit));
+  padding-bottom: calc(2 * var(--space-unit));
+  padding-top: calc(2 * var(--space-unit));
 
   @include mq(sm) {
     padding-bottom: calc(9 * var(--space-unit));
@@ -63,6 +63,7 @@
   @extend %heading-display;
   @include heading-fancy($space-above: var(--space-lg));
   font-weight: normal;
+  margin-top: 0;
 }
 
 .cc-full-width-promo__title-link {
@@ -75,7 +76,6 @@
   display: flex;
   flex-wrap: wrap;
   margin-bottom: calc(2 * var(--space-unit));
-  padding-bottom: var(--space-unit);
   padding-top: var(--space-unit);
 }
 

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -102,6 +102,7 @@
   @extend %heading-large;
 
   font-weight: normal;
+  margin-top: 0;
 
   @include mq($until: sm) {
     margin-bottom: calc(0.5 * var(--space-unit));
@@ -129,7 +130,6 @@
   font-size: var(--body-xs);
   text-transform: uppercase;
 }
-
 
 // VARIANTS
 // standard - begins in a horizontal format and switches to a vertical format

--- a/src/components/ImageCardWithCTA/_image-card-with-cta.scss
+++ b/src/components/ImageCardWithCTA/_image-card-with-cta.scss
@@ -5,12 +5,12 @@
 
 .cc-image-card-with-cta {
   margin-bottom: var(--space-lg);
-  
+
   @include mq($until: md) {
     display: flex;
     flex-wrap: nowrap;
   }
-  
+
   @include mq(md) {
     flex-basis: calc(33.33% - #{$grid-gutter-md});
     flex-grow: 0;
@@ -18,52 +18,52 @@
     margin: $grid-gutter-md / 2;
     padding-bottom: var(--space-unit);
   }
-  
+
   @include mq(xl) {
     flex-basis: calc(33.33% - #{$grid-gutter-xl});
     margin: $grid-gutter-xl / 2;
   }
 }
-  
+
 .cc-image-card-with-cta__figure {
   display: block;
   flex-basis: 33.33%;
   flex-shrink: 0;
-  
+
   @include mq(md) {
     margin-bottom: calc(2 * var(--space-unit));
   }
 }
-  
+
 .cc-image-card-with-cta__image {
   @extend %img-responsive;
   @extend %img-cover;
   margin: 0;
-  
+
   // ensure all card images have the same aspect ratio to enforce the same height
   @include mq(md) {
     padding-bottom: 66.67%;
     position: relative;
-  
+
     > img {
       position: absolute;
     }
   }
 }
-  
+
 .cc-image-card-with-cta__body {
   flex-grow: 1;
   padding-left: var(--space-unit);
-  
+
   @include mq(sm) {
     padding-left: calc(2 * var(--space-unit));
   }
-  
+
   @include mq(md) {
     padding-left: 0;
   }
 }
-  
+
 .cc-image-card-with-cta__title {
   letter-spacing: 0;
 }
@@ -74,23 +74,27 @@
   @include heading-fancy;
 
   font-weight: normal;
-  
+
   letter-spacing: 0;
   margin-bottom: calc(2 * var(--space-unit));
 
   @include mq($until: sm) {
     margin-bottom: calc(0.5 * var(--space-unit));
   }
+
+  &:after {
+    margin-top: var(--space-unit);
+  }
 }
-  
+
 .cc-image-card-with-cta__link {
   @extend %anchor-inherit;
   @include animated-underline;
-  
+
   /**
-     * Imitate the hover state when a user hovers over the image of
-     * card.
-     */
+   * Imitate the hover state when a user hovers over the image of
+   * card.
+   */
   .cc-image-card-with-cta__figure:hover + .cc-image-card-with-cta__body &,
   .cc-image-card-with-cta__figure:focus + .cc-image-card-with-cta__body & {
     background-size: 100% 2px;
@@ -98,11 +102,11 @@
     transition-timing-function: var(--transition-timing-function-in);
   }
 }
-  
+
 .cc-image-card-with-cta__description {
   flex-grow: 1;
   margin-bottom: calc(2 * var(--space-unit));
-  
+
   @include mq(md) {
     padding-left: 0;
   }


### PR DESCRIPTION
# Context

When design QAing the updated homepage, it was requested to make various style updates to the Card/FeaturedPromo/FullWidthPromo components which are used in that page.

See https://github.com/wellcometrust/corporate/issues/8383 for a breakdown of these changes and some discussion.

# Description

Copy/pasted from wellcometrust/corporate/issues/8383:

- [x] `cc-featured-promo__link` font should be same as `cc-image-card__link`
- [x] `cc-image-card__link` change top margin to 16px 
- [x] `cc-full-width-promo__container grid` change `padding-top:16px` and `padding-bottom: 16px` currently 60px
- [x] `cc-full-width-promo__title-link` change `margin-top: 0`
- [x] Change to `margin-top: 0.5rem`  for yellow block underline ( `cc-image-card-with-cta__title:after `)
- [x] `cc-image-card__title` change `margin-top: 0`

There are some changes from wellcometrust/corporate/issues/8383 which require further discussion and have not been made in this PR. They will be addressed in a future PR if required as they require more invasive changes than simple one/two line style changes.

# Testing

1. Follow the `npm link` process locally
2. `npm run dev` in corporate react (ensure API is coming from https://cms.wellcome.org)
3. Go to http://localhost:3001
4. Check styles on homepage are as expected