### PR TITLE
8430 task: add hidden error text

### DIFF
--- a/src/components/FormFieldError/FormFieldError.tsx
+++ b/src/components/FormFieldError/FormFieldError.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 
 import Icon from 'Icon';
+import VisuallyHidden from 'VisuallyHidden';
 
 type FormFieldErrorProps = {
   className?: string;
@@ -29,10 +30,16 @@ export const FormFieldError = ({
     <span className={classNames} id={id}>
       <Icon className="cc-form-field-error__icon" name="exclamationMark" />
       {typeof errors === 'string' && (
-        <p className="cc-form-field-error__text">{errors}</p>
+        <p className="cc-form-field-error__text">
+          <VisuallyHidden text="Error:" />
+          {errors}
+        </p>
       )}
       {typeof errors === 'object' && Object.entries(errors).length === 1 && (
-        <p className="cc-form-field-error__text">{Object.values(errors)[0]}</p>
+        <p className="cc-form-field-error__text">
+          <VisuallyHidden text="Error:" />
+          {Object.values(errors)[0]}
+        </p>
       )}
       {typeof errors === 'object' && Object.entries(errors).length > 1 && (
         <ul className="cc-form-field-error__list">
@@ -41,6 +48,7 @@ export const FormFieldError = ({
               key={`${id}-error-text-${type}`}
               className="cc-form-field-error__list-item"
             >
+              <VisuallyHidden text="Error:" />
               {message}
             </li>
           ))}

--- a/src/components/FormFieldError/FormFieldError.tsx
+++ b/src/components/FormFieldError/FormFieldError.tsx
@@ -31,13 +31,17 @@ export const FormFieldError = ({
       <Icon className="cc-form-field-error__icon" name="exclamationMark" />
       {typeof errors === 'string' && (
         <p className="cc-form-field-error__text">
-          <VisuallyHidden text="Error:" />
+          <VisuallyHidden>
+            <>Error: </>
+          </VisuallyHidden>
           {errors}
         </p>
       )}
       {typeof errors === 'object' && Object.entries(errors).length === 1 && (
         <p className="cc-form-field-error__text">
-          <VisuallyHidden text="Error:" />
+          <VisuallyHidden>
+            <>Error: </>
+          </VisuallyHidden>
           {Object.values(errors)[0]}
         </p>
       )}
@@ -48,7 +52,9 @@ export const FormFieldError = ({
               key={`${id}-error-text-${type}`}
               className="cc-form-field-error__list-item"
             >
-              <VisuallyHidden text="Error:" />
+              <VisuallyHidden>
+                <>Error: </>
+              </VisuallyHidden>
               {message}
             </li>
           ))}

--- a/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
 
 type VisuallyHiddenProps = {
-  text: string;
+  children: JSX.Element | JSX.Element[];
+  wrapperAs?: 'span' | 'div';
 };
 
-export const VisuallyHidden = ({ text }: VisuallyHiddenProps) => {
-  return <span className="u-visually-hidden">{text}&nbsp;</span>;
+export const VisuallyHidden = ({
+  children,
+  wrapperAs = 'span',
+  ...props
+}: VisuallyHiddenProps) => {
+  const WrapperElement = wrapperAs;
+
+  return (
+    <WrapperElement className="u-visually-hidden" {...props}>
+      {children}
+    </WrapperElement>
+  );
 };
 
 export default VisuallyHidden;

--- a/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+type VisuallyHiddenProps = {
+  text: string;
+};
+
+export const VisuallyHidden = ({ text }: VisuallyHiddenProps) => {
+  return <span className="u-visually-hidden">{text}&nbsp;</span>;
+};
+
+export default VisuallyHidden;

--- a/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 
-type VisuallyHiddenProps = {
-  children: JSX.Element | JSX.Element[];
+type VisuallyHiddenProps = (
+  | HTMLAttributes<HTMLDivElement>
+  | HTMLAttributes<HTMLSpanElement>
+) & {
+  children: JSX.Element | JSX.Element[] | HTMLElement;
   wrapperAs?: 'span' | 'div';
 };
 

--- a/src/components/VisuallyHidden/index.ts
+++ b/src/components/VisuallyHidden/index.ts
@@ -1,0 +1,1 @@
+export { default } from './VisuallyHidden';

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export { default as TextCard } from 'TextCard';
 export { default as TextInput } from 'TextInput';
 export { default as Timeline } from 'Timeline';
 export { Video } from 'Video/Video';
+export { default as VisuallyHidden } from 'VisuallyHidden';
 export { WellcomeCollectionBanner } from 'WellcomeCollectionBanner/WellcomeCollectionBanner';
 
 // context components


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8430

### Context

The [gov.uk](https://design-system.service.gov.uk/components/error-message/) recommendation:

> To help screen reader users, the error message component includes a hidden ‘Error:’ before the error message. These users will hear, for example, “Error: The date your passport was issued must be in the past”.

### This PR

- adds the `VisuallyHidden` component
- adds visually hidden error text to `FormFieldErrror`

<img width="623" alt="Screenshot 2021-04-07 at 11 17 40" src="https://user-images.githubusercontent.com/10700103/113856002-9674eb00-9798-11eb-8717-23199f22f073.png">
