### PR TITLE
8395 task(style): H4,H5 and H6 should be in grey within accordion

### DIFF
--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -34,7 +34,9 @@
     font-size: var(--heading-sm);
   }
 
-  h4 {
+  h4,
+  h5,
+  h6 {
     color: var(--colour-grey-70);
   }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8395

### Context

This is an alternative to changing the font size for headings within accordion which is mentioned in [this ticket](https://github.com/wellcometrust/corporate/issues/8290).

### This PR

- changes the colour of H4, H5 and H6 within accordion to grey #5c5c5c

