### PR TITLE
8439 task: add Remove filter [filter] visually hidden text

### DIFF
--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Button from 'Button';
 import Accordion, { AccordionItem } from 'Accordion/Accordion';
 import Checkbox from 'Checkbox';
+import VisuallyHidden from 'VisuallyHidden';
 
 type SidebarFilterProps = {
   activeTags: {
@@ -71,6 +72,7 @@ export const SidebarFilter = ({
               onClick={() => onTagRemove(value)}
               type="button"
             >
+              <VisuallyHidden>Remove filter&nbsp;</VisuallyHidden>
               {label}
             </Button>
           ))}

--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -72,7 +72,7 @@ export const SidebarFilter = ({
               onClick={() => onTagRemove(value)}
               type="button"
             >
-              <VisuallyHidden>Remove filter&nbsp;</VisuallyHidden>
+              <VisuallyHidden>{`Remove filter `}</VisuallyHidden>
               {label}
             </Button>
           ))}

--- a/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -4,7 +4,7 @@ type VisuallyHiddenProps = (
   | HTMLAttributes<HTMLDivElement>
   | HTMLAttributes<HTMLSpanElement>
 ) & {
-  children: JSX.Element | JSX.Element[] | HTMLElement;
+  children: JSX.Element | JSX.Element[] | HTMLElement | string;
   wrapperAs?: 'span' | 'div';
 };
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8439

### Context

This is updated to follow the pattern seen on [the gov.uk page](https://www.gov.uk/search/all?keywords=tenant&level_one_taxon=3cf97f69-84de-41ae-bc7b-7e2cc238fa58&order=relevance)

This is read: `Remove filter Environment`
![Screenshot 2021-04-12 at 11 23 23](https://user-images.githubusercontent.com/10700103/114380174-ab2ef580-9b81-11eb-813d-5bf7eeebf338.png)

### This PR

- adds visually hidden `Remove filter` to `SidebarFilter`
