### PR TITLE
8436 task: add SkipLink component

### DIFF
--- a/src/assets/styles/30-components/__manifest.scss
+++ b/src/assets/styles/30-components/__manifest.scss
@@ -70,6 +70,7 @@
 @import './src/components/SidebarFilter/sidebar-filter';
 @import './src/components/SidebarSearch/sidebar-search';
 @import './src/components/SiteAlert/site-alert';
+@import './src/components/SkipLink/skip-link';
 @import './src/components/SlideshowHero/slideshow-hero';
 @import './src/components/SocialShare/social-share';
 @import './src/components/TableauChart/tableau';

--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -47,7 +47,7 @@ export const SidebarFilter = ({
 
   return (
     <div className={classNames}>
-      {skipLink && <SkipLink href={skipLink} skipLinkText="Skip to results" />}
+      <SkipLink href={skipLink} text="Skip to results" />
       <header className="cc-sidebar-filter__header">
         <h2 className="cc-sidebar-filter__header-title">Refine results</h2>
         <span className="cc-sidebar-filter__header-meta">

--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -18,7 +18,7 @@ type SidebarFilterProps = {
   onChange: (value: string) => void;
   onClear: () => void;
   onTagRemove: (value: string) => void;
-  skipLink: string;
+  skipLinkHref: string;
   tags: {
     name: string;
     items: {
@@ -38,7 +38,7 @@ export const SidebarFilter = ({
   onChange,
   onClear,
   onTagRemove,
-  skipLink,
+  skipLinkHref,
   tags
 }: SidebarFilterProps) => {
   const classNames = cx('cc-sidebar-filter', {
@@ -47,7 +47,7 @@ export const SidebarFilter = ({
 
   return (
     <div className={classNames}>
-      <SkipLink href={skipLink} text="Skip to results" />
+      <SkipLink href={skipLinkHref} text="Skip to results" />
       <header className="cc-sidebar-filter__header">
         <h2 className="cc-sidebar-filter__header-title">Refine results</h2>
         <span className="cc-sidebar-filter__header-meta">

--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Button from 'Button';
 import Accordion, { AccordionItem } from 'Accordion/Accordion';
 import Checkbox from 'Checkbox';
+import SkipLink from 'SkipLink';
 
 type SidebarFilterProps = {
   activeTags: {
@@ -16,6 +17,7 @@ type SidebarFilterProps = {
   onChange: (value: string) => void;
   onClear: () => void;
   onTagRemove: (value: string) => void;
+  skipLink: string;
   tags: {
     name: string;
     items: {
@@ -35,6 +37,7 @@ export const SidebarFilter = ({
   onChange,
   onClear,
   onTagRemove,
+  skipLink,
   tags
 }: SidebarFilterProps) => {
   const classNames = cx('cc-sidebar-filter', {
@@ -43,6 +46,7 @@ export const SidebarFilter = ({
 
   return (
     <div className={classNames}>
+      {skipLink && <SkipLink href={skipLink} skipLinkText="Skip to results" />}
       <header className="cc-sidebar-filter__header">
         <h2 className="cc-sidebar-filter__header-title">Refine results</h2>
         <span className="cc-sidebar-filter__header-meta">

--- a/src/components/SkipLink/SkipLink.md
+++ b/src/components/SkipLink/SkipLink.md
@@ -1,0 +1,5 @@
+# Skip Link
+
+## When to use
+
+Use the skip link component to help keyboard-only users skip to the main content on a page or skip to the results on a listing page.

--- a/src/components/SkipLink/SkipLink.stories.tsx
+++ b/src/components/SkipLink/SkipLink.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import SkipLink from 'SkipLink';
+
+const SkipLinkExample = () => {
+  const skipLinkText = text('text', 'Skip to main content');
+  const isNarrow = boolean('isNarrow', true);
+
+  return (
+    <>
+      <p>
+        To view the skip link component tab to this example, or click inside
+        this example and press tab.
+      </p>
+
+      <SkipLink href="#" isNarrow={isNarrow} skipLinkText={skipLinkText} />
+    </>
+  );
+};
+
+const stories = storiesOf('SkipLink', module);
+
+stories.add('SkipLink', SkipLinkExample);

--- a/src/components/SkipLink/SkipLink.stories.tsx
+++ b/src/components/SkipLink/SkipLink.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { boolean, text } from '@storybook/addon-knobs';
+import { select, text } from '@storybook/addon-knobs';
 
 import SkipLink from 'SkipLink';
 import Readme from './SkipLink.md';
 
 const SkipLinkExample = () => {
   const skipLinkText = text('text', 'Skip to main content');
-  const isNarrow = boolean('isNarrow', true);
+  const position = select('position', ['float', 'static'], 'static');
 
   return (
     <>
@@ -16,7 +16,7 @@ const SkipLinkExample = () => {
         this example and press tab.
       </p>
 
-      <SkipLink href="#" isNarrow={isNarrow} skipLinkText={skipLinkText} />
+      <SkipLink href="#" position={position} text={skipLinkText} />
     </>
   );
 };

--- a/src/components/SkipLink/SkipLink.stories.tsx
+++ b/src/components/SkipLink/SkipLink.stories.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { boolean, text } from '@storybook/addon-knobs';
 
 import SkipLink from 'SkipLink';
+import Readme from './SkipLink.md';
 
 const SkipLinkExample = () => {
   const skipLinkText = text('text', 'Skip to main content');
@@ -22,4 +23,6 @@ const SkipLinkExample = () => {
 
 const stories = storiesOf('SkipLink', module);
 
-stories.add('SkipLink', SkipLinkExample);
+stories.add('SkipLink', SkipLinkExample, {
+  readme: { sidebar: Readme }
+});

--- a/src/components/SkipLink/SkipLink.tsx
+++ b/src/components/SkipLink/SkipLink.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import cx from 'classnames';
+
+type SkipLinkProps = {
+  className?: string;
+  href: string;
+  isNarrow?: boolean;
+  skipLinkText: string;
+};
+
+export const SkipLink = ({
+  className,
+  href,
+  isNarrow,
+  skipLinkText
+}: SkipLinkProps) => {
+  const classNames = cx('cc-skip-link__link', {
+    'cc-skip-link__link--narrow': isNarrow,
+    [className]: className
+  });
+  return (
+    <div className="cc-skip-link">
+      <a className={classNames} href={href}>
+        {skipLinkText}
+      </a>
+    </div>
+  );
+};
+
+export default SkipLink;

--- a/src/components/SkipLink/SkipLink.tsx
+++ b/src/components/SkipLink/SkipLink.tsx
@@ -14,13 +14,18 @@ export const SkipLink = ({
   isNarrow,
   skipLinkText
 }: SkipLinkProps) => {
-  const classNames = cx('cc-skip-link__link', {
-    'cc-skip-link__link--narrow': isNarrow,
-    [className]: className
-  });
+  const classNames = {
+    wrapper: cx('cc-skip-link', {
+      [className]: className
+    }),
+    link: cx('cc-skip-link__link', {
+      'cc-skip-link__link--narrow': isNarrow
+    })
+  };
+
   return (
-    <div className="cc-skip-link">
-      <a className={classNames} href={href}>
+    <div className={classNames.wrapper}>
+      <a className={classNames.link} href={href}>
         {skipLinkText}
       </a>
     </div>

--- a/src/components/SkipLink/SkipLink.tsx
+++ b/src/components/SkipLink/SkipLink.tsx
@@ -4,29 +4,29 @@ import cx from 'classnames';
 type SkipLinkProps = {
   className?: string;
   href: string;
-  isNarrow?: boolean;
-  skipLinkText: string;
+  position?: 'static' | 'float';
+  text: string;
 };
 
 export const SkipLink = ({
   className,
   href,
-  isNarrow,
-  skipLinkText
+  position = 'static',
+  text
 }: SkipLinkProps) => {
   const classNames = {
     wrapper: cx('cc-skip-link', {
       [className]: className
     }),
     link: cx('cc-skip-link__link', {
-      'cc-skip-link__link--narrow': isNarrow
+      'cc-skip-link__link--float': position === 'float'
     })
   };
 
   return (
     <div className={classNames.wrapper}>
       <a className={classNames.link} href={href}>
-        {skipLinkText}
+        {text}
       </a>
     </div>
   );

--- a/src/components/SkipLink/_skip-link.scss
+++ b/src/components/SkipLink/_skip-link.scss
@@ -32,6 +32,6 @@
   }
 }
 
-.cc-skip-link__link--narrow:focus {
+.cc-skip-link__link--float:focus {
   position: absolute;
 }

--- a/src/components/SkipLink/_skip-link.scss
+++ b/src/components/SkipLink/_skip-link.scss
@@ -1,0 +1,37 @@
+// ----------------------------------
+// UI Components
+// Skip Link
+// ----------------------------------
+// Design System 1.0 Alpha
+// 2019-11-11
+// ----------------------------------
+
+.cc-skip-link {
+  margin: 0;
+  padding: 0;
+}
+
+.cc-skip-link__link {
+  clip: rect(0, 0, 0, 0);
+  height: 0;
+  position: absolute;
+  width: 0;
+
+  &:focus {
+    background-color: var(--colour-white);
+    border: 0;
+    clip: auto;
+    display: block;
+    height: auto;
+    line-height: normal;
+    padding: calc(2 * var(--space-unit)) calc(4 * var(--space-unit));
+    position: static;
+    text-decoration: none;
+    width: auto;
+    z-index: 210;
+  }
+}
+
+.cc-skip-link__link--narrow:focus {
+  position: absolute;
+}

--- a/src/components/SkipLink/index.ts
+++ b/src/components/SkipLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SkipLink';

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export { SearchPane } from 'SearchPane/SearchPane';
 export { Section } from 'Section/Section';
 export { SectionTitle } from 'SectionTitle/SectionTitle';
 export { default as SiteAlert } from 'SiteAlert';
+export { default as SkipLink } from 'SkipLink';
 export { default as SidebarFilter } from 'SidebarFilter';
 export { default as SidebarSearch } from 'SidebarSearch';
 export { SlideshowHero } from 'SlideshowHero/SlideshowHero';


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8436

### Context

[gov.uk](https://www.gov.uk/search/all?keywords=tax) page has a `Skip to results` link above the filter section

<img src="https://user-images.githubusercontent.com/10700103/114003040-56c00900-9855-11eb-8561-88bad751287b.png" />

### This PR

- adds `SkipLink` component

![Screenshot 2021-04-12 at 17 18 49](https://user-images.githubusercontent.com/10700103/114427635-2fe63780-9bb3-11eb-98ad-9bcda633e11d.png)

### Test

- fetch this branch and checkout 
- run `npm run storybook`