### PR TITLE
8450 task: add autocomplete and spellcheck attributes to TextInput

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -2,9 +2,10 @@ import React, { forwardRef } from 'react';
 import cx from 'classnames';
 
 type TextInputProps = {
-  autoComplete?: 'name' | 'tel' | 'email';
+  autoComplete?: string;
   className?: string;
   describedBy?: string;
+  hasSpellCheck?: boolean;
   id: string;
   inputMode?: 'numeric';
   isDisabled?: boolean;
@@ -12,7 +13,6 @@ type TextInputProps = {
   isRequired?: boolean;
   name: string;
   pattern?: string;
-  spellCheck?: 'true' | 'false';
   type: 'text' | 'email' | 'tel';
 };
 
@@ -22,6 +22,7 @@ export const TextInput = forwardRef(
       autoComplete,
       className,
       describedBy,
+      hasSpellCheck,
       id,
       inputMode,
       isDisabled,
@@ -29,7 +30,6 @@ export const TextInput = forwardRef(
       isRequired,
       name,
       pattern,
-      spellCheck,
       type = 'text'
     }: TextInputProps,
     ref: React.Ref<HTMLInputElement>
@@ -53,7 +53,7 @@ export const TextInput = forwardRef(
         pattern={pattern}
         ref={ref}
         required={isRequired}
-        spellCheck={spellCheck}
+        spellCheck={hasSpellCheck}
         type={type}
       />
     );

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import cx from 'classnames';
 
 type TextInputProps = {
+  autoComplete?: 'name' | 'tel' | 'email';
   className?: string;
   describedBy?: string;
   id: string;
@@ -11,12 +12,14 @@ type TextInputProps = {
   isRequired?: boolean;
   name: string;
   pattern?: string;
+  spellCheck?: 'true' | 'false';
   type: 'text' | 'email' | 'tel';
 };
 
 export const TextInput = forwardRef(
   (
     {
+      autoComplete,
       className,
       describedBy,
       id,
@@ -26,6 +29,7 @@ export const TextInput = forwardRef(
       isRequired,
       name,
       pattern,
+      spellCheck,
       type = 'text'
     }: TextInputProps,
     ref: React.Ref<HTMLInputElement>
@@ -40,6 +44,7 @@ export const TextInput = forwardRef(
       <input
         aria-describedby={describedBy}
         aria-invalid={isInvalid}
+        autoComplete={autoComplete}
         className={classNames}
         disabled={isDisabled}
         id={id}
@@ -48,6 +53,7 @@ export const TextInput = forwardRef(
         pattern={pattern}
         ref={ref}
         required={isRequired}
+        spellCheck={spellCheck}
         type={type}
       />
     );


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8450

### Context

> Use the autocomplete attribute on the text input component when you’re asking for a user’s name. This lets browsers autofill the information on a user’s behalf if they’ve entered it previously.

> Sometimes, browsers will spellcheck the information a user enters into a text input. To make sure user’s names will not be spellchecked, set the spellcheck attribute to false

source: [gov.uk design system: names pattern](https://design-system.service.gov.uk/patterns/names/)

After accessibility training and checking the gov.uk design system we should:

- set the autocomplete attribute to `name` - if asking for a user’s full name in a single field
- set the autocomplete attribute `tel` on telephone number inputs
- set the autocomplete attribute to `email` on email inputs
- do not spellcheck user’s names nor email addresses

**sources**

- [gov.uk design system: names pattern](https://design-system.service.gov.uk/patterns/names/)
- [gov.uk design system: telephone numbers pattern](https://design-system.service.gov.uk/patterns/telephone-numbers/)
- [gov.uk design system: email pattern](https://design-system.service.gov.uk/patterns/email-addresses/)

### This PR

- adds `autoComplete` and `spellCheck` props to `TextInput`