### PR TITLE
8440 task: add accessible range text for ResultsCount

### DIFF
--- a/src/components/ResultsCount/ResultsCount.tsx
+++ b/src/components/ResultsCount/ResultsCount.tsx
@@ -1,6 +1,8 @@
 import React, { ChangeEvent } from 'react';
 import cx from 'classnames';
-import Label from '../Label';
+
+import Label from 'Label';
+import VisuallyHidden from 'VisuallyHidden';
 
 type ResultsCountProps = {
   className?: string;
@@ -30,16 +32,22 @@ export const ResultsCount = ({
     [className]: className
   });
 
+  const accessibleText = /-/.test(currentCount)
+    ? currentCount.replace('-', ' to ')
+    : currentCount;
+
   return (
     <div className={classNames}>
       <p
-        className="cc-results-count__result"
         aria-atomic="true"
         aria-live="polite"
+        className="cc-results-count__result"
       >
         Showing{' '}
         <strong>
-          {currentCount} results of {resultsCount}
+          <VisuallyHidden>{accessibleText}</VisuallyHidden>
+          <span aria-hidden="true">{currentCount}</span> results of{' '}
+          {resultsCount}
         </strong>
       </p>
       {options ? (

--- a/src/components/ResultsCount/_results-count.scss
+++ b/src/components/ResultsCount/_results-count.scss
@@ -19,6 +19,7 @@
 }
 
 .cc-results-count__result {
+  margin-bottom: calc(3 * var(--space-unit));
   margin-top: 0;
   padding-top: calc(3 * var(--space-unit));
 

--- a/src/components/ResultsCount/_results-count.scss
+++ b/src/components/ResultsCount/_results-count.scss
@@ -9,7 +9,7 @@
 .cc-results-count {
   border-top: 1px solid var(--colour-grey-10);
   font-size: var(--body-md);
-  padding-bottom: var(--space-lg);
+  padding-bottom: calc(3 * var(--space-unit));
 
   @include mq(sm) {
     align-items: center;
@@ -20,11 +20,11 @@
 
 .cc-results-count__result {
   margin-top: 0;
-  padding-top: var(--space-lg);
+  padding-top: calc(3 * var(--space-unit));
 
   @include mq(sm) {
     margin-bottom: 0;
-    padding-bottom: var(--space-lg);
+    padding-bottom: calc(3 * var(--space-unit));
   }
 }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8440

### Context

As a screen reader user I would like to hear a clear message about results range.

We use a hyphen to indicate the results range, it currently reads: "Showing 1 9 results of 9"

To make it clear we can include the word "to" i.e. "Showing 1 to 9 results of 9"

### This PR

- implements [@creido-welly 's comment](https://github.com/wellcometrust/corporate-react/pull/940#pullrequestreview-638715549)
- adds accessible range results text i.e.`1 to 20`

