### PR TITLE
8488 Feature: Disabled file inputs

### DIFF
--- a/src/components/FileInput/_file-input.scss
+++ b/src/components/FileInput/_file-input.scss
@@ -56,3 +56,7 @@
   position: relative;
 }
 
+.cc-file-input__text.is-disabled {
+  color: var(--colour-grey-60);
+}
+

--- a/src/components/FileInput/_file-input.scss
+++ b/src/components/FileInput/_file-input.scss
@@ -27,7 +27,32 @@
   }
 }
 
+.cc-file-input[disabled] {
+  + .btn {
+    color: var(--link-colour-disabled);
+    cursor: not-allowed;
+
+    @include hocus {
+      color: var(--link-colour-disabled);
+    }
+  }
+
+  + .btn--primary {
+    background-color: var(--colour-grey-20);
+  }
+
+  + .btn--secondary {
+    background-color: var(--colour-grey-20);
+    border-color: var(--link-colour-disabled);
+  }
+
+  + .btn--ghost {
+    border-color: var(--link-colour-disabled);
+  }
+}
+
 .btn--file-input {
   margin-bottom: var(--space-sm);
   position: relative;
 }
+


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8488

Styled file inputs implement their visible button by restyling their label. This means that the disabled appearance is not respected when applied to the file input. 

This PR adds classes to rectify this - plus a class to display extended text descriptions as disabled