### PR TITLE
8447 task(style): non-responsive body styles

### DIFF
--- a/src/assets/styles/10-settings/_typography.scss
+++ b/src/assets/styles/10-settings/_typography.scss
@@ -24,9 +24,10 @@
   --body-xl: calc(20/16 * var(--text-base-size));     // Large
   --body-lg: var(--text-base-size);                   // Regular
   --body-md: calc(14/16 * var(--text-base-size));     // Small
-  --body-sm: calc(13/16 * var(--text-base-size));     // Smaller
+  --body-sm: calc(13/16 * var(--text-base-size));     //
 
 
+  --body-xs: calc(12/16 * var(--text-base-size));      // Smaller
   --body-xxs: calc(11/16 * var(--text-base-size));     //
   --body-xxxs: calc(10/16 * var(--text-base-size));    //
 

--- a/src/assets/styles/10-settings/_typography.scss
+++ b/src/assets/styles/10-settings/_typography.scss
@@ -25,9 +25,9 @@
   --body-lg: var(--text-base-size);                   // Regular
   --body-md: calc(14/16 * var(--text-base-size));     // Small
   --body-sm: calc(13/16 * var(--text-base-size));     // Smaller
-  --body-xs: calc(11/16 * var(--text-base-size));     // Smallest
 
 
+  --body-xxs: calc(11/16 * var(--text-base-size));     //
   --body-xxxs: calc(10/16 * var(--text-base-size));    //
 
   // font size responsive headings

--- a/src/assets/styles/10-settings/_typography.scss
+++ b/src/assets/styles/10-settings/_typography.scss
@@ -22,16 +22,12 @@
 
   // font size - non-responsive body text
   --body-xl: calc(24/16 * var(--text-base-size));     // Extra Large
-
-
-  --body-lg: var(--text-base-size);                   // Regular
-  --body-md: calc(14/16 * var(--text-base-size));     // Small
-  --body-sm: calc(13/16 * var(--text-base-size));     //
-
-
-  --body-xs: calc(12/16 * var(--text-base-size));      // Smaller
-  --body-xxs: calc(11/16 * var(--text-base-size));     //
-  --body-xxxs: calc(10/16 * var(--text-base-size));    //
+  --body-lg: calc(20/16 * var(--text-base-size));     // Large
+  --body-md: var(--text-base-size);                   // Regular
+  --body-sm: calc(14/16 * var(--text-base-size));     // Small
+  --body-xs: calc(12/16 * var(--text-base-size));     // Smaller
+  --body-xxs: calc(11/16 * var(--text-base-size));    // wellcome.org specific font-size
+  --body-xxxs: calc(10/16 * var(--text-base-size));   // wellcome.org specific font-size
 
   // font size responsive headings
   --heading-xxl: calc(32/16 * var(--text-base-size)); // Super

--- a/src/assets/styles/10-settings/_typography.scss
+++ b/src/assets/styles/10-settings/_typography.scss
@@ -26,7 +26,9 @@
   --body-md: calc(14/16 * var(--text-base-size));     // Small
   --body-sm: calc(13/16 * var(--text-base-size));     // Smaller
   --body-xs: calc(11/16 * var(--text-base-size));     // Smallest
-  --body-xxs: calc(10/16 * var(--text-base-size));    //
+
+
+  --body-xxxs: calc(10/16 * var(--text-base-size));    //
 
   // font size responsive headings
   --heading-xxl: calc(32/16 * var(--text-base-size)); // Super

--- a/src/assets/styles/10-settings/_typography.scss
+++ b/src/assets/styles/10-settings/_typography.scss
@@ -21,7 +21,9 @@
   --text-base-size-px: 16;
 
   // font size - non-responsive body text
-  --body-xl: calc(20/16 * var(--text-base-size));     // Large
+  --body-xl: calc(24/16 * var(--text-base-size));     // Extra Large
+
+
   --body-lg: var(--text-base-size);                   // Regular
   --body-md: calc(14/16 * var(--text-base-size));     // Small
   --body-sm: calc(13/16 * var(--text-base-size));     //

--- a/src/assets/styles/20-tools/_extends/_forms.scss
+++ b/src/assets/styles/20-tools/_extends/_forms.scss
@@ -25,7 +25,7 @@
   width: 100%;
 
   @include mq(md) {
-    font-size: var(--body-md);
+    font-size: var(--body-sm);
   }
 
   &::placeholder {

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -177,7 +177,7 @@
 // Accordion variant: filter
 .cc-accordion--filter {
   .cc-accordion__button {
-    font-size: var(--body-md);
+    font-size: var(--body-sm);
   }
 
   .cc-accordion__button .icon {

--- a/src/components/Author/_author.scss
+++ b/src/components/Author/_author.scss
@@ -41,5 +41,5 @@
 .cc-author__byline {
   @extend %margin-0;
 
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
 }

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -98,7 +98,7 @@
 }
 
 .cc-card__title {
-  font-size: var(--body-lg);
+  font-size: var(--body-md);
   font-weight: bold;
   margin-bottom: var(--space-sm);
   margin-top: 0;
@@ -136,7 +136,7 @@
 .cc-card__author,
 .cc-card__date {
   color: var(--meta-text-colour);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   line-height: var(--body-line-height);
 }
 

--- a/src/components/Contact/_contact.scss
+++ b/src/components/Contact/_contact.scss
@@ -42,7 +42,7 @@
 }
 
 .cc-contact__name {
-  font-size: var(--body-lg);
+  font-size: var(--body-md);
   font-weight: bold;
   margin: 0 0 var(--space-sm);
 }

--- a/src/components/DescriptionList/_description-list.scss
+++ b/src/components/DescriptionList/_description-list.scss
@@ -1,7 +1,7 @@
 .cc-description-list__title {
   display: block;
   float: left;
-  font-size: var(--body-lg);
+  font-size: var(--body-md);
   font-weight: bold;
 
   margin: 0 var(--space-sm) 0 0;

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -63,7 +63,7 @@
 
 .cc-featured-promo__meta-item--label {
   color: var(--colour-grey-60);
-  font-size: var(--body-xs);
+  font-size: var(--body-xxs);
   text-transform: uppercase;
 }
 
@@ -107,7 +107,7 @@
 
 .cc-featured-promo__date {
   display: block;
-  font-size: var(--body-xs);
+  font-size: var(--body-xxs);
   margin-bottom: calc(2 * var(--space-unit));
   text-transform: uppercase;
 }

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -79,7 +79,7 @@
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin-bottom: 0;
   margin-top: 0;
 }

--- a/src/components/FileDownload/_file-download.scss
+++ b/src/components/FileDownload/_file-download.scss
@@ -5,5 +5,5 @@
 
 .cc-file-download__meta {
   color: var(--meta-text-colour);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
 }

--- a/src/components/Footer/FooterNav/_footer-nav.scss
+++ b/src/components/Footer/FooterNav/_footer-nav.scss
@@ -8,7 +8,7 @@
 // ----------------------------------
 
 .footer-nav {
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
 }
 
 .footer-nav__grid {
@@ -66,7 +66,7 @@
   @include animated-underline($height: calc(0.125 * var(--space-unit)));
 
   display: inline-block;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin-bottom: var(--space-xs);
   margin-top: var(--space-xs);
   text-decoration: none;

--- a/src/components/FormFieldError/_form-field-error.scss
+++ b/src/components/FormFieldError/_form-field-error.scss
@@ -10,7 +10,7 @@
   align-items: center;
   color: var(--colour-red-60);
   display: flex;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin-bottom: var(--space-xs);
 }
 

--- a/src/components/FormFieldHint/_form-field-hint.scss
+++ b/src/components/FormFieldHint/_form-field-hint.scss
@@ -8,7 +8,7 @@
 
 .cc-form-field-hint {
   color: var(--meta-text-colour);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin-bottom: var(--space-xs);
 
   p {

--- a/src/components/FullWidthPromo/_full-width-promo.scss
+++ b/src/components/FullWidthPromo/_full-width-promo.scss
@@ -81,7 +81,7 @@
 
 .cc-full-width-promo__type {
   color: var(--colour-grey-60);
-  font-size: var(--body-xs);
+  font-size: var(--body-xxs);
   margin: 0;
   text-transform: uppercase;
 

--- a/src/components/FullWidthPromo/_full-width-promo.scss
+++ b/src/components/FullWidthPromo/_full-width-promo.scss
@@ -105,7 +105,7 @@
 }
 
 .cc-full-width-promo__author {
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin: 0;
 
   + .cc-full-width-promo__author:before {

--- a/src/components/GalleryLightBox/_gallery-lightbox.scss
+++ b/src/components/GalleryLightBox/_gallery-lightbox.scss
@@ -362,7 +362,7 @@
   @extend %btn-size-standard;
   align-items: center;
   display: inline-flex;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin-left: var(--space-md);
 }
 

--- a/src/components/GalleryLightBox/_gallery-lightbox.scss
+++ b/src/components/GalleryLightBox/_gallery-lightbox.scss
@@ -19,7 +19,7 @@
 
 %top-padding {
   padding-top: calc(6 * var(--space-unit));
-  
+
   @include mq(sm) {
     padding-top: calc(12 * var(--space-unit));
   }
@@ -198,7 +198,7 @@
 .cc-gallery-lightbox__info-pane {
   @extend %bottom-padding;
   grid-area: info;
-    
+
   @include mq(md) {
     overflow-y: auto;
   }
@@ -238,7 +238,7 @@
 /**
  * Start child component styles; these are the 'smaller' components
  * which make up the individual elements within each slide.
- * 
+ *
  * Component | Grid area
  * --------- | ---------
  * Actions   | actions
@@ -309,7 +309,7 @@
 .cc-gallery-lightbox__meta {
   border-left: 1px solid var(--colour-white);
   font-family: var(--font-tertiary);
-  font-size: var(--body-xs);
+  font-size: var(--body-xxs);
   -webkit-font-smoothing: auto;
   margin-bottom: calc(2 * var(--space-unit));
   padding-left: var(--space-md);
@@ -369,7 +369,7 @@
 .cc-gallery-lightbox__nav {
   align-items: center;
   display: flex;
-  
+
   @include mq($until: md) {
     margin-left: calc(-1.75 * var(--space-unit));
   }
@@ -426,14 +426,14 @@
  * Image
  */
 
-.cc-gallery-lightbox__image {  
+.cc-gallery-lightbox__image {
 
   // Setting / overriding pure-react-carousel styles
   .carousel__image {
     background-position: 50% 50% !important;
     background-repeat: no-repeat !important;
     background-size: contain !important;
-    
+
     bottom: 0;
     display: block;
     left: 0;
@@ -441,7 +441,7 @@
     right: 0;
     top: 0;
   }
-  
+
   .carousel__image:not(.carousel__zoom-image-overlay) {
     @include mq(sm) {
       background-position: 50% 0 !important;

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -64,7 +64,7 @@
 
 .cc-image-card__meta-item--label {
   color: var(--colour-grey-60);
-  font-size: var(--body-xs);
+  font-size: var(--body-xxs);
   text-transform: uppercase;
 }
 
@@ -127,7 +127,7 @@
 
 .cc-image-card__date {
   display: block;
-  font-size: var(--body-xs);
+  font-size: var(--body-xxs);
   text-transform: uppercase;
 }
 

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -80,7 +80,7 @@
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin-bottom: 0;
   margin-top: 0;
 }

--- a/src/components/InpageNav/_inpage-nav.scss
+++ b/src/components/InpageNav/_inpage-nav.scss
@@ -41,7 +41,7 @@
 
 .cc-inpage-nav__title {
   display: block;
-  font-size: var(--body-xxs);
+  font-size: var(--body-xxxs);
   font-weight: 500;
   line-height: 2.4;
   margin-bottom: var(--space-unit);
@@ -61,15 +61,15 @@
   text-decoration: none;
   transition: ease var(--transition-duration-fast);
   transition-property: border, color, padding;
-  
+
   @include hocus {
     color: var(--colour-blue-70);
   }
-  
+
   &:active {
     color: var(--colour-blue-50);
   }
-  
+
   &.is-active {
     border-left-color: var(--colour-blue-60);
     color: var(--colour-grey-80);

--- a/src/components/InpageNav/_inpage-nav.scss
+++ b/src/components/InpageNav/_inpage-nav.scss
@@ -20,7 +20,7 @@
 
 .cc-inpage-nav {
   @include grid-column(1, 7);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   letter-spacing: var(--body-letter-spacing);
   line-height: var(--body-line-height);
 

--- a/src/components/Listing/_listing.scss
+++ b/src/components/Listing/_listing.scss
@@ -45,7 +45,7 @@
 
 .cc-listing__link-meta {
   color: var(--meta-text-colour);
-  font-size: var(--body-xs);
+  font-size: var(--body-xxs);
 }
 
 .cc-listing__link-icon {

--- a/src/components/Media/_media.scss
+++ b/src/components/Media/_media.scss
@@ -33,7 +33,7 @@
   border: 0;
   border-left: 1px solid var(--colour-grey-70);
   color: var(--colour-grey-70);
-  font-size: var(--body-xs);
+  font-size: var(--body-xxs);
   line-height: var(--body-line-height);
   margin-top: calc(2 * var(--space-unit));
   padding: calc(0.25 * var(--space-unit)) 0 calc(0.25 * var(--space-unit)) calc(2 * var(--space-unit));

--- a/src/components/NewsletterForm/_newsletter-form.scss
+++ b/src/components/NewsletterForm/_newsletter-form.scss
@@ -71,7 +71,7 @@
   background-image: none;
   border-radius: calc(0.25 * var(--space-unit));
   color: var(--X-colour-error-red);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin-top: var(--space-md);
   padding-bottom: var(--space-xs);
   padding-left: var(--space-sm);
@@ -96,7 +96,7 @@
 /* Labels */
 
 .newsletter-form__item-label {
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   line-height: rem(20.53); // #6171 refactor footer styles
   margin-bottom: var(--space-xs);
 }
@@ -127,11 +127,11 @@
 
 .newsletter-form__btn-submit {
   width: 100%;
-  
+
   @include mq(sm) {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
-  }  
+  }
 }
 
 /* Response Messages */

--- a/src/components/NewsletterSignup/_newsletter-signup.scss
+++ b/src/components/NewsletterSignup/_newsletter-signup.scss
@@ -54,6 +54,6 @@
 }
 
 .newsletter-signup .newsletter-form__item--footer {
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   line-height: var(--body-line-height);
 }

--- a/src/components/PageHeaderCompact/_page-header-compact.scss
+++ b/src/components/PageHeaderCompact/_page-header-compact.scss
@@ -69,9 +69,9 @@
      * .cc-page-title__meta margin-bottom +
      * .cc-page-title__meta line-height * font-size * 0.5
      */
-    margin-top: calc(var(--body-md) +
+    margin-top: calc(var(--body-sm) +
     (2 * var(--space-unit)) +
-    (var(--body-line-height) * var(--body-md) * 0.5));
+    (var(--body-line-height) * var(--body-sm) * 0.5));
   }
 }
 
@@ -126,7 +126,7 @@
   border-top: 1px solid var(--colour-grey-05);
   color: var(--colour-grey-60);
   display: flex;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   justify-content: space-between;
   padding-bottom: calc(2 * var(--space-unit));
   padding-top: calc(2 * var(--space-unit));

--- a/src/components/PageTitle/_page-title.scss
+++ b/src/components/PageTitle/_page-title.scss
@@ -9,10 +9,9 @@
 .cc-page-title {
   @extend %heading-base;
   @extend %heading-hero;
-  @include heading-divider;
+  @include heading-fancy;
 
   font-family: var(--font-secondary);
-  text-align: center;
 }
 
 .cc-page-title__meta {

--- a/src/components/PageTitle/_page-title.scss
+++ b/src/components/PageTitle/_page-title.scss
@@ -18,7 +18,7 @@
 .cc-page-title__meta {
   color: var(--meta-text-colour);
   display: block;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   margin-bottom: calc(2 * var(--space-unit));
   text-align: center;
 }

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -40,7 +40,7 @@
   align-items: center;
   cursor: pointer;
   display: flex;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   padding: var(--space-unit);
   text-decoration: none;
 }

--- a/src/components/ResultsCount/_results-count.scss
+++ b/src/components/ResultsCount/_results-count.scss
@@ -8,7 +8,7 @@
 
 .cc-results-count {
   border-top: 1px solid var(--colour-grey-10);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   padding-bottom: calc(3 * var(--space-unit));
 
   @include mq(sm) {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -22,20 +22,17 @@
   h3 {
     @extend %heading-base;
     @extend %heading-large;
-    letter-spacing: 0;
   }
 
   h4 {
     @extend %heading-base;
     @extend %heading-regular;
-    letter-spacing: 0;
   }
 
   h5,
   h6 {
     @extend %heading-base;
     @extend %heading-small;
-    letter-spacing: 0;
   }
 
   p {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -16,8 +16,7 @@
   h2 {
     @extend %heading-base;
     @extend %heading-display;
-    @include heading-divider;
-    text-align: center;
+    @include heading-fancy;
   }
 
   h3 {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -101,7 +101,7 @@
   }
 
   td {
-    font-size: var(--body-md);
+    font-size: var(--body-sm);
   }
 }
 
@@ -127,7 +127,7 @@
 .cc-rich-text-snippet h5,
 .cc-rich-text-snippet h6 {
   @extend %heading-base;
-  font-size: var(--body-lg);
+  font-size: var(--body-md);
   font-weight: bold;
   letter-spacing: normal;
   margin-bottom: var(--space-unit);

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -91,7 +91,7 @@
   }
 
   th {
-    font-size: var(--body-xxs);
+    font-size: var(--body-xxxs);
     font-weight: 500;
     text-transform: uppercase;
   }

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -63,7 +63,7 @@
   caption {
     border-left: 1px solid var(--colour-grey-70);
     font-family: var(--font-tertiary);
-    font-size: var(--body-xs);
+    font-size: var(--body-xxs);
     font-weight: bold;
     margin-bottom: calc(2 * var(--space-unit));
     padding: calc(0.25 * var(--space-unit)) 0 calc(0.25 * var(--space-unit)) calc(2 * var(--space-unit));

--- a/src/components/SectionTitle/_section-title.scss
+++ b/src/components/SectionTitle/_section-title.scss
@@ -9,9 +9,8 @@
 .cc-section__title {
   @extend %heading-base;
   @extend %heading-display;
-  @include heading-divider;
+  @include heading-fancy;
   position: relative;
-  text-align: center;
 
   @include mq(md) {
     z-index: var(--z-medium);
@@ -24,7 +23,7 @@
   position: absolute;
   top: calc(-1 * (var(--header-height) + var(--secondary-nav-height)));
   visibility: hidden;
-  
+
   @include mq(sm) {
     top: calc(-1 * (var(--header-height-sm) + var(--secondary-nav-height)));
   }

--- a/src/components/SidebarFilter/_sidebar-filter.scss
+++ b/src/components/SidebarFilter/_sidebar-filter.scss
@@ -31,11 +31,9 @@
 }
 
 .cc-sidebar-filter__tags-list-item {
-  --body-sm: calc(12/16 * var(--text-base-size));
-
   background-color: var(--colour-blue-05);
   color: var(--colour-blue-60);
-  font-size: var(--body-sm);
+  font-size: var(--body-xs);
   justify-content: space-between;
   margin-bottom: var(--space-md);
   text-align: left;

--- a/src/components/SidebarFilter/_sidebar-filter.scss
+++ b/src/components/SidebarFilter/_sidebar-filter.scss
@@ -10,7 +10,7 @@
 
 .cc-sidebar-filter__header-title {
   flex-shrink: 1;
-  font-size: var(--body-lg);
+  font-size: var(--body-md);
   line-height: var(--body-line-height);
   margin-bottom: 0;
   margin-top: 0;
@@ -18,11 +18,11 @@
 
 .cc-sidebar-filter__header-meta {
   color: var(--colour-grey-30);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
 }
 
 .cc-sidebar-filter__btn-clear {
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
 }
 
 .cc-sidebar-filter__tags-list {
@@ -76,7 +76,7 @@
 }
 
 .cc-sidebar-filter__checkbox {
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
 
   .cc-checkbox__label {
     padding-bottom: var(--space-md);

--- a/src/components/SidebarSearch/_sidebar-search.scss
+++ b/src/components/SidebarSearch/_sidebar-search.scss
@@ -15,7 +15,7 @@
   font-weight: bold;
 
   .cc-sidebar-filter & {
-    font-size: var(--body-md);
+    font-size: var(--body-sm);
   }
 }
 

--- a/src/components/SiteAlert/_site-alert.scss
+++ b/src/components/SiteAlert/_site-alert.scss
@@ -27,7 +27,7 @@
   background: var(--site-alert-colour-yellow);
   bottom: 0;
   display: flex;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   height: var(--site-alert-height);
   justify-content: space-between;
   left: 0;
@@ -83,7 +83,7 @@
   color: var(--colour-grey-80);
   cursor: pointer;
   display: flex;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   padding: var(--space-unit);
   position: relative;
 

--- a/src/components/SocialShare/_social-share.scss
+++ b/src/components/SocialShare/_social-share.scss
@@ -22,7 +22,7 @@
   cursor: pointer;
   display: block;
   padding: calc(1.5 * var(--space-unit));
-  
+
   @include hocus {
     .cc-social-share__icon {
       border-color: var(--colour-grey-80);
@@ -56,7 +56,7 @@
   border: 1px solid var(--colour-grey-40);
   color: var(--colour-white);
   display: block;
-  font-size: var(--body-sm);
+  font-size: var(--body-xs);
   left: calc(1.5 * var(--space-unit));
   padding: var(--space-unit);
   pointer-events: none;

--- a/src/components/TableauChart/_tableau.scss
+++ b/src/components/TableauChart/_tableau.scss
@@ -15,7 +15,7 @@
     position: relative;
     width: 100%;
   }
-  
+
   .tableauViz {
     display: none;
     min-height: 627px;
@@ -28,11 +28,11 @@
 // awaiting data for toggling extra wide
 // .cc-tableau__chart {
 //   @include grid-column(1, 7);
-  
+
 //   @include mq(sm) {
 //     @include grid-column(1, 13);
 //   }
-  
+
 //   @include mq(md) {
 //     @include grid-column(4, 10);
 //   }
@@ -49,7 +49,7 @@
 }
 
 .cc-tableau__title {
-  font-size: var(--body-lg);
+  font-size: var(--body-md);
   font-weight: bold;
   margin-bottom: var(--space-sm);
   margin-top: 0;

--- a/src/components/TextCard/_text-card.scss
+++ b/src/components/TextCard/_text-card.scss
@@ -6,7 +6,7 @@
 }
 
 .cc-text-card__title {
-  font-size: var(--body-lg);
+  font-size: var(--body-md);
   margin-bottom: var(--space-xs);
   margin-top: var(--space-xs);
 }
@@ -26,7 +26,7 @@
 }
 
 .cc-text-card__meta {
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   line-height: 1.57143;
   margin-bottom: var(--space-xs);
 }
@@ -61,7 +61,7 @@
 
 .cc-text-card__file-meta-size {
   color: var(--meta-text-colour);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
 }
 
 .cc-text-card__list {

--- a/src/components/Timeline/_timeline.scss
+++ b/src/components/Timeline/_timeline.scss
@@ -9,11 +9,10 @@
 // .cc-timeline {}
 
 .cc-timeline__title {
-  @include heading-divider;
+  @include heading-fancy;
   font-size: var(--heading-md);
   letter-spacing: 0;
   margin-bottom: calc(4 * var(--space-unit));
-  text-align: center;
 }
 
 .cc-timeline__description {

--- a/src/components/Timeline/_timeline.scss
+++ b/src/components/Timeline/_timeline.scss
@@ -9,10 +9,9 @@
 // .cc-timeline {}
 
 .cc-timeline__title {
+  @extend %heading-base;
+  @extend %heading-large;
   @include heading-fancy;
-  font-size: var(--heading-md);
-  letter-spacing: 0;
-  margin-bottom: calc(4 * var(--space-unit));
 }
 
 .cc-timeline__description {

--- a/src/components/Timeline/_timeline.scss
+++ b/src/components/Timeline/_timeline.scss
@@ -23,7 +23,7 @@
 .cc-timeline__status {
   background-color: var(--colour-cyan-05);
   float: right;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   font-weight: bold;
   line-height: 2.14;
   padding-bottom: calc(0.5 * var(--space-unit));
@@ -96,7 +96,7 @@
   color: var(--meta-text-colour);
   flex-grow: 0;
   flex-shrink: 0;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   line-height: calc(24/14);
 
   @include mq(sm) {
@@ -125,7 +125,7 @@
 
 .cc-timeline__item-body {
   color: var(--meta-text-colour);
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
 
   p {
     margin: 0;

--- a/src/components/Video/_video.scss
+++ b/src/components/Video/_video.scss
@@ -27,6 +27,6 @@
 }
 
 .cc-video__caption {
-  font-size: var(--body-sm);
+  font-size: var(--body-xs);
   margin-bottom: 0;
 }

--- a/src/components/WellcomeCollectionBanner/_wellcome-collection-banner.scss
+++ b/src/components/WellcomeCollectionBanner/_wellcome-collection-banner.scss
@@ -24,7 +24,7 @@
   background: var(--wc-banner-colour-yellow);
   bottom: 0;
   display: flex;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   height: var(--wc-banner-height);
   justify-content: space-between;
   left: 0;
@@ -76,7 +76,7 @@
   color: var(--wc-banner-colour-text);
   cursor: pointer;
   display: flex;
-  font-size: var(--body-md);
+  font-size: var(--body-sm);
   padding: var(--space-unit);
   position: relative;
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8447

### Context

We have an updated design for headings and copy on the site -> https://www.sketch.com/s/0e43fb67-e700-4c05-a0db-a7dad402bcc3/a/v8QlPq3

Apologies for another non-responsive body style updates PR, I found it easier to start from scratch, and make sure the fonts are updated correctly.

My previous PR removed the wellcome.org specific font-size (11px), but we want to keep it.

After chat with Jason I have removed 13px font-size as it was used only once and replaced it with 12px.

### This PR

- updates the non-responsive body text font-size to match the design system
- adds new font-size variables for wellcome.org specific styles
