### PR TITLE
8447 task(style): updates headings to have fancy underline

### DIFF
--- a/src/components/PageTitle/_page-title.scss
+++ b/src/components/PageTitle/_page-title.scss
@@ -9,10 +9,9 @@
 .cc-page-title {
   @extend %heading-base;
   @extend %heading-hero;
-  @include heading-divider;
+  @include heading-fancy;
 
   font-family: var(--font-secondary);
-  text-align: center;
 }
 
 .cc-page-title__meta {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -22,20 +22,17 @@
   h3 {
     @extend %heading-base;
     @extend %heading-large;
-    letter-spacing: 0;
   }
 
   h4 {
     @extend %heading-base;
     @extend %heading-regular;
-    letter-spacing: 0;
   }
 
   h5,
   h6 {
     @extend %heading-base;
     @extend %heading-small;
-    letter-spacing: 0;
   }
 
   p {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -16,8 +16,7 @@
   h2 {
     @extend %heading-base;
     @extend %heading-display;
-    @include heading-divider;
-    text-align: center;
+    @include heading-fancy;
   }
 
   h3 {

--- a/src/components/SectionTitle/_section-title.scss
+++ b/src/components/SectionTitle/_section-title.scss
@@ -9,9 +9,8 @@
 .cc-section__title {
   @extend %heading-base;
   @extend %heading-display;
-  @include heading-divider;
+  @include heading-fancy;
   position: relative;
-  text-align: center;
 
   @include mq(md) {
     z-index: var(--z-medium);
@@ -24,7 +23,7 @@
   position: absolute;
   top: calc(-1 * (var(--header-height) + var(--secondary-nav-height)));
   visibility: hidden;
-  
+
   @include mq(sm) {
     top: calc(-1 * (var(--header-height-sm) + var(--secondary-nav-height)));
   }

--- a/src/components/Timeline/_timeline.scss
+++ b/src/components/Timeline/_timeline.scss
@@ -9,11 +9,10 @@
 // .cc-timeline {}
 
 .cc-timeline__title {
-  @include heading-divider;
+  @include heading-fancy;
   font-size: var(--heading-md);
   letter-spacing: 0;
   margin-bottom: calc(4 * var(--space-unit));
-  text-align: center;
 }
 
 .cc-timeline__description {

--- a/src/components/Timeline/_timeline.scss
+++ b/src/components/Timeline/_timeline.scss
@@ -9,10 +9,9 @@
 // .cc-timeline {}
 
 .cc-timeline__title {
+  @extend %heading-base;
+  @extend %heading-large;
   @include heading-fancy;
-  font-size: var(--heading-md);
-  letter-spacing: 0;
-  margin-bottom: calc(4 * var(--space-unit));
 }
 
 .cc-timeline__description {


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8447

### Context

We have an updated design for headings and copy on the site -> https://www.sketch.com/s/0e43fb67-e700-4c05-a0db-a7dad402bcc3/a/v8QlPq3


### This PR

- adds fancy underline to the headings

Examples:

![Screenshot 2021-04-28 at 15 57 41](https://user-images.githubusercontent.com/10700103/116436424-4bed0880-a844-11eb-9734-24bd126d87ba.png)

![Screenshot 2021-04-28 at 16 01 19](https://user-images.githubusercontent.com/10700103/116436431-4db6cc00-a844-11eb-857e-aa092415ee94.png)


