### PR TITLE
8447 task(style): design QA

### DIFF
--- a/src/assets/styles/10-settings/_typography.scss
+++ b/src/assets/styles/10-settings/_typography.scss
@@ -47,7 +47,7 @@
   --heading-minor-letter-spacing: 0.2px;
 
   // font weight
-  --font-weight: 500;
+  --heading-font-weight: 500;
 
   @include mq(sm) {
     --heading-xl: calc(32/16 * var(--text-base-size));

--- a/src/assets/styles/10-settings/_typography.scss
+++ b/src/assets/styles/10-settings/_typography.scss
@@ -46,6 +46,9 @@
   --heading-major-letter-spacing: -0.5px;
   --heading-minor-letter-spacing: 0.2px;
 
+  // font weight
+  --font-weight: 500;
+
   @include mq(sm) {
     --heading-xl: calc(32/16 * var(--text-base-size));
     --heading-lg: calc(24/16 * var(--text-base-size));

--- a/src/assets/styles/20-tools/_extends/_typography.scss
+++ b/src/assets/styles/20-tools/_extends/_typography.scss
@@ -97,6 +97,7 @@
 // equivalent to <h2>
 %heading-display {
   font-size: var(--heading-lg);
+  font-weight: var(--font-weight);
   letter-spacing: var(--heading-minor-letter-spacing);
   margin-bottom: var(--space-lg);
 }
@@ -104,6 +105,7 @@
 // equivalent to <h3>
 %heading-large {
   font-size: var(--heading-md);
+  font-weight: var(--font-weight);
   letter-spacing: var(--heading-minor-letter-spacing);
   margin-bottom: var(--space-lg);
 }
@@ -111,6 +113,7 @@
 // equivalent to <h4>
 %heading-regular {
   font-size: var(--heading-sm);
+  font-weight: var(--font-weight);
   letter-spacing: var(--heading-minor-letter-spacing);
   margin-bottom: var(--space-md);
 }
@@ -118,6 +121,7 @@
 // equivalent to <h5>
 %heading-small {
   font-size: var(--heading-xs);
+  font-weight: var(--font-weight);
   letter-spacing: var(--heading-minor-letter-spacing);
   margin-bottom: var(--space-md);
 }

--- a/src/assets/styles/20-tools/_extends/_typography.scss
+++ b/src/assets/styles/20-tools/_extends/_typography.scss
@@ -97,7 +97,7 @@
 // equivalent to <h2>
 %heading-display {
   font-size: var(--heading-lg);
-  font-weight: var(--font-weight);
+  font-weight: var(--heading-font-weight);
   letter-spacing: var(--heading-minor-letter-spacing);
   margin-bottom: var(--space-lg);
 }
@@ -105,7 +105,7 @@
 // equivalent to <h3>
 %heading-large {
   font-size: var(--heading-md);
-  font-weight: var(--font-weight);
+  font-weight: var(--heading-font-weight);
   letter-spacing: var(--heading-minor-letter-spacing);
   margin-bottom: var(--space-lg);
 }
@@ -113,7 +113,7 @@
 // equivalent to <h4>
 %heading-regular {
   font-size: var(--heading-sm);
-  font-weight: var(--font-weight);
+  font-weight: var(--heading-font-weight);
   letter-spacing: var(--heading-minor-letter-spacing);
   margin-bottom: var(--space-md);
 }
@@ -121,7 +121,7 @@
 // equivalent to <h5>
 %heading-small {
   font-size: var(--heading-xs);
-  font-weight: var(--font-weight);
+  font-weight: var(--heading-font-weight);
   letter-spacing: var(--heading-minor-letter-spacing);
   margin-bottom: var(--space-md);
 }

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -30,16 +30,6 @@
 .cc-accordion__content {
   padding: var(--space-unit) 0;
 
-  h3 {
-    font-size: var(--heading-sm);
-  }
-
-  h4,
-  h5,
-  h6 {
-    color: var(--colour-grey-70);
-  }
-
   .cc-accordion + *,
   .cc-rich-text + * {
     margin-top: calc(2 * var(--space-sm));

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -101,8 +101,6 @@
   @extend %heading-base;
   @extend %heading-large;
   @include heading-fancy;
-
-  margin-bottom: calc(2 * var(--space-unit));
 }
 
 .cc-featured-promo__date {

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -102,10 +102,11 @@
   @extend %heading-large;
 
   font-weight: normal;
+  margin-bottom: var(--space-unit);
   margin-top: 0;
 
-  @include mq($until: sm) {
-    margin-bottom: calc(0.5 * var(--space-unit));
+  @include mq(sm) {
+    margin-bottom: calc(2 * var(--space-unit));
   }
 }
 

--- a/src/components/InpageNav/_inpage-nav.scss
+++ b/src/components/InpageNav/_inpage-nav.scss
@@ -42,7 +42,7 @@
 .cc-inpage-nav__title {
   display: block;
   font-size: var(--body-xxxs);
-  font-weight: 500;
+  font-weight: var(--heading-font-weight);
   line-height: 2.4;
   margin-bottom: var(--space-unit);
   text-transform: uppercase;

--- a/src/components/PageTitle/_page-title.scss
+++ b/src/components/PageTitle/_page-title.scss
@@ -22,5 +22,5 @@
 }
 
 .cc-page-title__meta-label {
-  font-weight: 500;
+  font-weight: var(--heading-font-weight);
 }

--- a/src/components/PageTitle/_page-title.scss
+++ b/src/components/PageTitle/_page-title.scss
@@ -19,7 +19,6 @@
   display: block;
   font-size: var(--body-sm);
   margin-bottom: calc(2 * var(--space-unit));
-  text-align: center;
 }
 
 .cc-page-title__meta-label {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -89,7 +89,7 @@
 
   th {
     font-size: var(--body-xxxs);
-    font-weight: 500;
+    font-weight: var(--heading-font-weight);
     text-transform: uppercase;
   }
 

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -22,6 +22,7 @@
   h3 {
     @extend %heading-base;
     @extend %heading-large;
+    @include heading-fancy;
   }
 
   h4 {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -22,7 +22,6 @@
   h3 {
     @extend %heading-base;
     @extend %heading-large;
-    @include heading-fancy;
   }
 
   h4 {

--- a/src/components/Timeline/_timeline.scss
+++ b/src/components/Timeline/_timeline.scss
@@ -11,7 +11,6 @@
 .cc-timeline__title {
   @extend %heading-base;
   @extend %heading-large;
-  @include heading-fancy;
 }
 
 .cc-timeline__description {


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8447

### Context

We have an updated design for headings and copy on the site -> https://www.sketch.com/s/0e43fb67-e700-4c05-a0db-a7dad402bcc3/a/v8QlPq3

### This PR

Implements Jason's design QA. More can be seen here: https://docs.google.com/spreadsheets/d/1uUWk7s8b_nr6F2upj06RShHQPW2dgB2N0zyRyYioFR4/edit#gid=0

- removes custom headings sizes within accordion
- adds font-weight 500 to Helvetica headings
- update space for `FeaturedPromo` and `ImageCard` components
- removes fancy underline from H3 in `RichText` nad `Timeline`