### PR TITLE
8561 task: updates SiteAlert props

### DIFF
--- a/src/components/SiteAlert/SiteAlert.tsx
+++ b/src/components/SiteAlert/SiteAlert.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Icon from 'Icon/Icon';
 
 type SiteAlertProps = {
+  className?: string;
   handleDismiss?: () => void;
   isActive: boolean;
   text: string;
@@ -11,12 +12,14 @@ type SiteAlertProps = {
 };
 
 export const SiteAlert = ({
+  className,
   handleDismiss,
   isActive,
   text,
   url
 }: SiteAlertProps) => {
   const classNames = cx('site-alert', {
+    [className]: className,
     'is-active': isActive
   });
 
@@ -37,15 +40,17 @@ export const SiteAlert = ({
         ) : (
           <p className="site-alert__text">{text}</p>
         )}
-        <button
-          className="site-alert__btn-close"
-          onClick={handleDismiss}
-          type="button"
-          tabIndex={tabIndex}
-        >
-          Close
-          <Icon name="closeBold" />
-        </button>
+        {typeof handleDismiss === 'function' && (
+          <button
+            className="site-alert__btn-close"
+            onClick={handleDismiss}
+            type="button"
+            tabIndex={tabIndex}
+          >
+            Close
+            <Icon name="closeBold" />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/SiteAlert/_site-alert.scss
+++ b/src/components/SiteAlert/_site-alert.scss
@@ -73,6 +73,9 @@
 
 .site-alert__text {
   @extend %margin-0;
+
+  text-align: center;
+  width: 100%;
 }
 
 .site-alert__btn-close {
@@ -92,9 +95,4 @@
     margin-left: var(--space-unit);
     width: calc(1.5 * var(--space-unit));
   }
-}
-
-.site-alert__text {
-  width: 100%;
-  text-align: center;
 }

--- a/src/components/SiteAlert/_site-alert.scss
+++ b/src/components/SiteAlert/_site-alert.scss
@@ -93,3 +93,8 @@
     width: calc(1.5 * var(--space-unit));
   }
 }
+
+.site-alert__text {
+  width: 100%;
+  text-align: center;
+}


### PR DESCRIPTION
# Context

As part of the preview work being done over at /issues/7988, we want to use the SiteAlert (aka "Collection banner") style for the "Preview mode" message.

To do this, it's necessary to pass a custom classname to the SiteAlert (so that we can style it accordingly, when the SiteAlert exists in a different place in the DOM - e.g. not as a child of the site header).

We also don't want to pass the `handleDismiss` callback, because the user should not be able to close this message; it should always remain present. Therefore we want to make the `handleDismiss` prop optional.

# Description

This PR:

- sets `handleDismiss` optional
- conditionally renders the `<button>` element based on presence of `handleDismiss`
- adds `className` prop