### PR TITLE
8554 task: yellow links and buttons

### DIFF
--- a/src/assets/styles/10-settings/_colours.scss
+++ b/src/assets/styles/10-settings/_colours.scss
@@ -50,9 +50,9 @@
 
   --link-colour: var(--colour-blue-60);
   --link-colour-hover: var(--colour-blue-70);
-  --link-colour-focus-outline: var(--colour-blue-40);
+  --link-colour-focus-outline: var(--colour-blue-50);
   --link-colour-active: var(--colour-blue-50);
-  --link-colour-disabled: var(--colour-grey-50);
+  --link-colour-disabled: var(--colour-grey-40);
 
   --body-text-colour: var(--colour-grey-80);
   --meta-text-colour: var(--colour-grey-60);

--- a/src/assets/styles/10-settings/_colours.scss
+++ b/src/assets/styles/10-settings/_colours.scss
@@ -48,10 +48,10 @@
   --colour-red-90: #40120d;
   --colour-red-60: #e10f2d;
 
-  --link-colour: var(--colour-blue-60);
-  --link-colour-hover: var(--colour-blue-70);
+  --link-colour: var(--colour-grey-80);
+  --link-colour-hover: var(--colour-grey-80);
   --link-colour-focus-outline: var(--colour-blue-50);
-  --link-colour-active: var(--colour-blue-50);
+  --link-colour-active: var(--colour-grey-80);
   --link-colour-disabled: var(--colour-grey-40);
 
   --body-text-colour: var(--colour-grey-80);

--- a/src/assets/styles/10-settings/_transition.scss
+++ b/src/assets/styles/10-settings/_transition.scss
@@ -9,4 +9,6 @@
 :root {
   --transition-duration-fast: 0.2s;
   --transition-duration: 0.4s;
+  --transition-timing-function-in: cubic-bezier(0.23, 1, 0.32, 1);
+  --transition-timing-function-out: cubic-bezier(0.55, 0.085, 0.68, 0.53);
 }

--- a/src/assets/styles/20-tools/_extends/_button.scss
+++ b/src/assets/styles/20-tools/_extends/_button.scss
@@ -15,10 +15,10 @@
   cursor: pointer;
   display: flex;
   letter-spacing: var(--body-letter-spacing);
-  line-height: 1;
+  line-height: var(--body-line-height);
   padding: 0;
   text-decoration: none;
-  
+
   &:hover {
     text-decoration: none;
   }

--- a/src/assets/styles/20-tools/_mixins/_typography.scss
+++ b/src/assets/styles/20-tools/_mixins/_typography.scss
@@ -99,6 +99,7 @@
   $underline-colour: var(--colour-grey-80),
   $selector: null
 ) {
+  @extend %anchor-base;
 
   text-decoration: none;
 

--- a/src/assets/styles/20-tools/_mixins/_typography.scss
+++ b/src/assets/styles/20-tools/_mixins/_typography.scss
@@ -54,16 +54,16 @@
  * i.e. hover-underline adds styles to a title after the image was hovered
  */
 @mixin default-underline($height: 3px, $underline-colour: var(--colour-grey-80)) {
-  --transition-duration: 0.35s;
+  --transition-duration-link: 0.3s;
   --transition-timing-function: ease-in-out;
 
   background-image: linear-gradient($underline-colour, $underline-colour), linear-gradient(transparent, transparent);
   background-position: left calc(100% - #{$height});
   background-repeat: no-repeat;
   background-size: 100% 1px, 0 $height;
-  padding-bottom: 5px;
+  padding-bottom: 6px;
 
-  transition: var(--transition-duration) var(--transition-timing-function);
+  transition: var(--transition-duration-link) var(--transition-timing-function);
   transition-property: background-size;
 }
 
@@ -99,8 +99,6 @@
   $underline-colour: var(--colour-grey-80),
   $selector: null
 ) {
-  --transition-duration: 0.35s;
-  --transition-timing-function: ease-in-out;
 
   text-decoration: none;
 

--- a/src/assets/styles/20-tools/_mixins/_typography.scss
+++ b/src/assets/styles/20-tools/_mixins/_typography.scss
@@ -49,6 +49,93 @@
 }
 
 /**
+ * Generates a style where a horizontal line displays
+ * beneath an element and changes to another colour on hover with a transition.
+ *
+ * @param {Int} $height - height of the "underline"
+ * @param {string} $underline-colour - colour of the "underline"
+ * @param {string} $animated-colour - colour of the "underline" on hover
+ */
+@mixin animated-double-underline($height: 3px, $underline-colour: var(--colour-grey-80), $animated-colour: var(--colour-amber-30)) {
+  --transition-duration: 0.3s;
+  --transition-timing-function-in: cubic-bezier(0.23, 1, 0.32, 1);
+  --transition-timing-function-out: cubic-bezier(0.55, 0.085, 0.68, 0.53);
+
+  background-image: linear-gradient($animated-colour, $animated-colour);
+  background-position: left bottom;
+  background-repeat: no-repeat;
+  background-size: 0 $height;
+  border-bottom: 1px solid $underline-colour;
+  padding-bottom: 3px;
+
+  text-decoration: none;
+  transition: var(--transition-duration) var(--transition-timing-function-out);
+  transition-property: background-size, border-bottom-color;
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+
+  &:hover {
+    background-size: 100% $height;
+    border-bottom-color: transparent;
+    transition-timing-function: var(--transition-timing-function-in);
+  }
+}
+
+/**
+ * Generates a style where a horizontal line displays
+ * beneath an element and changes to another colour on hover with a transition.
+ * The styles are added to the child of an anchor (default is span)
+ *
+ * Usage:
+ * For HTML <a class="cc-cta-link" href=''><span class="btn__text">Text</span></a>
+ *
+ * .cc-cta-link {
+ *   @include animated-link($selector: ".btn__text");
+ * }
+ *
+ * @param {Int} $height - height of the "underline"
+ * @param {string} $underline-colour - colour of the "underline"
+ * @param {string} $animated-colour - colour of the "underline" on hover
+ * @param {string} $selector - selector to apply anchor styles
+ */
+@mixin animated-link($height: 3px, $underline-colour: var(--colour-grey-80), $animated-colour: var(--colour-amber-30), $selector: 'span') {
+  --transition-duration: 0.3s;
+  --transition-timing-function-in: cubic-bezier(0.23, 1, 0.32, 1);
+  --transition-timing-function-out: cubic-bezier(0.55, 0.085, 0.68, 0.53);
+
+  text-decoration: none;
+
+  > #{$selector} {
+    background-image: linear-gradient($animated-colour, $animated-colour);
+    background-position: left bottom;
+    background-repeat: no-repeat;
+    background-size: 0 $height;
+
+    border-bottom: 1px solid $underline-colour;
+    padding-bottom: 2px;
+
+    transition: var(--transition-duration) var(--transition-timing-function-out);
+    transition-property: background-size, border-bottom-color;
+  }
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+
+  &:hover {
+    > #{$selector} {
+      background-size: 100% $height;
+      border-bottom-color: transparent;
+      transition-timing-function: var(--transition-timing-function-in);
+    }
+  }
+}
+
+/**
  * "Fancy" heading style; adds an :after element containing
  * a block of colour of varying widths/height/spacing above
  * dependent on parameters passed.

--- a/src/assets/styles/20-tools/_mixins/_typography.scss
+++ b/src/assets/styles/20-tools/_mixins/_typography.scss
@@ -81,7 +81,7 @@
  * For HTML <a class="cc-cta-link" href=''><span class="btn__text">Text</span></a>
  *
  * .cc-cta-link {
- *   @include animated-link($selector: ".btn__text");
+ *   @include animated-link($child-selector: ".btn__text");
  * }
  * or
  * a {
@@ -91,13 +91,13 @@
  * @param {Int} $height - height of the "underline" on hover
  * @param {string} $hover-colour - colour of the "underline" on hover
  * @param {string} $underline-colour - colour of the "underline" (default state)
- * @param {string} $selector - selector to apply anchor styles
+ * @param {string} $child-selector - selector to apply anchor styles
  */
 @mixin animated-link(
   $height: 3px,
   $hover-colour: var(--colour-amber-30),
   $underline-colour: var(--colour-grey-80),
-  $selector: null
+  $child-selector: null
 ) {
   @extend %anchor-base;
 
@@ -108,13 +108,13 @@
     text-decoration: none;
   }
 
-  @if ($selector) {
+  @if ($child-selector) {
 
-    #{$selector} {
+    #{$child-selector} {
       @include default-underline($height, $underline-colour);
     }
 
-    &:hover #{$selector} {
+    &:hover #{$child-selector} {
       @include hover-underline($height, $hover-colour);
     }
   }

--- a/src/assets/styles/20-tools/_mixins/_typography.scss
+++ b/src/assets/styles/20-tools/_mixins/_typography.scss
@@ -48,7 +48,15 @@
   }
 }
 
+/**
+ * Helper mixins - to reduce the animated-link mixin size and can be reused,
+ *
+ * i.e. hover-underline adds styles to a title after the image was hovered
+ */
 @mixin default-underline($height: 3px, $underline-colour: var(--colour-grey-80)) {
+  --transition-duration: 0.35s;
+  --transition-timing-function: ease-in-out;
+
   background-image: linear-gradient($underline-colour, $underline-colour), linear-gradient(transparent, transparent);
   background-position: left calc(100% - #{$height});
   background-repeat: no-repeat;
@@ -57,6 +65,12 @@
 
   transition: var(--transition-duration) var(--transition-timing-function);
   transition-property: background-size;
+}
+
+@mixin hover-underline($height: 3px, $hover-colour: var(--colour-amber-30)) {
+  background-image: linear-gradient(transparent, transparent), linear-gradient($hover-colour, $hover-colour);
+  background-position: left calc(100% - 1px);
+  background-size: 0 1px, 100% $height;
 }
 
 /**
@@ -101,20 +115,16 @@
       @include default-underline($height, $underline-colour);
     }
 
-    &:hover {
-      > #{$selector} {
-        background-image: linear-gradient(transparent, transparent), linear-gradient($hover-colour, $hover-colour);
-        background-position: left calc(100% - 1px);
-        background-size: 0 1px, 100% $height;
-      }
+    &:hover > #{$selector} {
+      @include hover-underline($height, $hover-colour);
     }
-  } @else {
+  }
+
+  @else {
     @include default-underline($height, $underline-colour);
 
     &:hover {
-      background-image: linear-gradient(transparent, transparent), linear-gradient($hover-colour, $hover-colour);
-      background-position: left calc(100% - 1px);
-      background-size: 0 1px, 100% $height;
+      @include hover-underline($height, $hover-colour);
     }
   }
 }

--- a/src/assets/styles/20-tools/_mixins/_typography.scss
+++ b/src/assets/styles/20-tools/_mixins/_typography.scss
@@ -111,11 +111,11 @@
 
   @if ($selector) {
 
-    > #{$selector} {
+    #{$selector} {
       @include default-underline($height, $underline-colour);
     }
 
-    &:hover > #{$selector} {
+    &:hover #{$selector} {
       @include hover-underline($height, $hover-colour);
     }
   }

--- a/src/assets/styles/20-tools/_mixins/_typography.scss
+++ b/src/assets/styles/20-tools/_mixins/_typography.scss
@@ -48,46 +48,20 @@
   }
 }
 
-/**
- * Generates a style where a horizontal line displays
- * beneath an element and changes to another colour on hover with a transition.
- *
- * @param {Int} $height - height of the "underline"
- * @param {string} $underline-colour - colour of the "underline"
- * @param {string} $animated-colour - colour of the "underline" on hover
- */
-@mixin animated-double-underline($height: 3px, $underline-colour: var(--colour-grey-80), $animated-colour: var(--colour-amber-30)) {
-  --transition-duration: 0.3s;
-  --transition-timing-function-in: cubic-bezier(0.23, 1, 0.32, 1);
-  --transition-timing-function-out: cubic-bezier(0.55, 0.085, 0.68, 0.53);
-
-  background-image: linear-gradient($animated-colour, $animated-colour);
-  background-position: left bottom;
+@mixin default-underline($height: 3px, $underline-colour: var(--colour-grey-80)) {
+  background-image: linear-gradient($underline-colour, $underline-colour), linear-gradient(transparent, transparent);
+  background-position: left calc(100% - #{$height});
   background-repeat: no-repeat;
-  background-size: 0 $height;
-  border-bottom: 1px solid $underline-colour;
-  padding-bottom: 3px;
+  background-size: 100% 1px, 0 $height;
+  padding-bottom: 5px;
 
-  text-decoration: none;
-  transition: var(--transition-duration) var(--transition-timing-function-out);
-  transition-property: background-size, border-bottom-color;
-
-  &:hover,
-  &:focus {
-    text-decoration: none;
-  }
-
-  &:hover {
-    background-size: 100% $height;
-    border-bottom-color: transparent;
-    transition-timing-function: var(--transition-timing-function-in);
-  }
+  transition: var(--transition-duration) var(--transition-timing-function);
+  transition-property: background-size;
 }
 
 /**
  * Generates a style where a horizontal line displays
  * beneath an element and changes to another colour on hover with a transition.
- * The styles are added to the child of an anchor (default is span)
  *
  * Usage:
  * For HTML <a class="cc-cta-link" href=''><span class="btn__text">Text</span></a>
@@ -95,42 +69,52 @@
  * .cc-cta-link {
  *   @include animated-link($selector: ".btn__text");
  * }
+ * or
+ * a {
+ *  @include animated-link;
+ * }
  *
- * @param {Int} $height - height of the "underline"
- * @param {string} $underline-colour - colour of the "underline"
- * @param {string} $animated-colour - colour of the "underline" on hover
+ * @param {Int} $height - height of the "underline" on hover
+ * @param {string} $hover-colour - colour of the "underline" on hover
+ * @param {string} $underline-colour - colour of the "underline" (default state)
  * @param {string} $selector - selector to apply anchor styles
  */
-@mixin animated-link($height: 3px, $underline-colour: var(--colour-grey-80), $animated-colour: var(--colour-amber-30), $selector: 'span') {
-  --transition-duration: 0.3s;
-  --transition-timing-function-in: cubic-bezier(0.23, 1, 0.32, 1);
-  --transition-timing-function-out: cubic-bezier(0.55, 0.085, 0.68, 0.53);
+@mixin animated-link(
+  $height: 3px,
+  $hover-colour: var(--colour-amber-30),
+  $underline-colour: var(--colour-grey-80),
+  $selector: null
+) {
+  --transition-duration: 0.35s;
+  --transition-timing-function: ease-in-out;
 
   text-decoration: none;
-
-  > #{$selector} {
-    background-image: linear-gradient($animated-colour, $animated-colour);
-    background-position: left bottom;
-    background-repeat: no-repeat;
-    background-size: 0 $height;
-
-    border-bottom: 1px solid $underline-colour;
-    padding-bottom: 2px;
-
-    transition: var(--transition-duration) var(--transition-timing-function-out);
-    transition-property: background-size, border-bottom-color;
-  }
 
   &:hover,
   &:focus {
     text-decoration: none;
   }
 
-  &:hover {
+  @if ($selector) {
+
     > #{$selector} {
-      background-size: 100% $height;
-      border-bottom-color: transparent;
-      transition-timing-function: var(--transition-timing-function-in);
+      @include default-underline($height, $underline-colour);
+    }
+
+    &:hover {
+      > #{$selector} {
+        background-image: linear-gradient(transparent, transparent), linear-gradient($hover-colour, $hover-colour);
+        background-position: left calc(100% - 1px);
+        background-size: 0 1px, 100% $height;
+      }
+    }
+  } @else {
+    @include default-underline($height, $underline-colour);
+
+    &:hover {
+      background-image: linear-gradient(transparent, transparent), linear-gradient($hover-colour, $hover-colour);
+      background-position: left calc(100% - 1px);
+      background-size: 0 1px, 100% $height;
     }
   }
 }

--- a/src/assets/styles/50-utilities/__manifest.scss
+++ b/src/assets/styles/50-utilities/__manifest.scss
@@ -6,7 +6,7 @@
 // ----------------------------------
 
 @import 'a11y';
+@import 'colour';
 @import 'external-link-indicator';
 @import 'links';
 @import 'loading';
-@import 'colour';

--- a/src/assets/styles/50-utilities/_links.scss
+++ b/src/assets/styles/50-utilities/_links.scss
@@ -1,12 +1,11 @@
 // ----------------------------------
 // UI Settings
+// Links
 // ----------------------------------
 // Design System 1.0 Alpha
 // 2019-11-11
 // ----------------------------------
 
-@import 'a11y';
-@import 'external-link-indicator';
-@import 'links';
-@import 'loading';
-@import 'colour';
+.u-animated-link {
+  @include animated-link;
+}

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -45,7 +45,7 @@ const ButtonExample = () => {
   const iconPlacementSwitch = boolean('iconPlacementSwitch', false);
   const variant = select(
     'variant',
-    ['primary', 'secondary', 'ghost', 'link', 'unstyled'],
+    ['primary', 'secondary', 'tertiary', 'link', 'unstyled'],
     'primary'
   );
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -24,7 +24,7 @@ type ButtonProps = {
   tabIndex?: number;
   textClassName?: string;
   type?: string;
-  variant?: 'primary' | 'secondary' | 'ghost' | 'link' | 'unstyled';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'link' | 'unstyled';
 };
 
 export const Button = forwardRef(

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -57,18 +57,6 @@
   }
 }
 
-.btn--link {
-  color: var(--link-colour);
-
-  &:hover {
-    color: var(--link-colour-hover);
-  }
-
-  &:active {
-    color: var(--link-colour-active);
-  }
-}
-
 .btn--secondary {
   background-color: var(--colour-amber-20);
 
@@ -109,6 +97,10 @@
   &[disabled] .btn__text {
     border-bottom-color: transparent;
   }
+}
+
+.btn--link {
+  @include animated-link($selector: '.btn__text');
 }
 
 .btn__icon--left {

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -24,7 +24,7 @@
 
 .btn--primary,
 .btn--secondary,
-.btn--ghost {
+.btn--tertiary {
   @extend %btn-size-standard;
 
   color: var(--colour-grey-80);
@@ -70,7 +70,7 @@
   }
 }
 
-.btn--ghost {
+.btn--tertiary {
   background-color: transparent;
 
   &:hover {

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -83,7 +83,7 @@
 }
 
 .btn--ghost {
-  background-color: var(--colour-white);
+  background-color: transparent;
 
   &:hover {
     background-color: var(--colour-amber-20);
@@ -91,7 +91,7 @@
 
   &:focus,
   &[disabled] {
-    background-color: var(--colour-white);
+    background-color: transparent;
   }
 
   &:active {
@@ -99,7 +99,7 @@
   }
 
   .btn__text {
-    border-bottom: 1px solid var(--colour-blue-80);
+    border-bottom: 1px solid var(--colour-grey-80);
     transition: ease 0.4s;
     transition-property: border-bottom-color;
   }

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -5,11 +5,11 @@
   font-family: var(--font-primary);
   font-size: var(--text-base-size);
   transition: ease 0.4s;
-  transition-property: background, border, color;
+  transition-property: background-color;
 
   &:focus {
     outline-color: var(--link-colour-focus-outline);
-    outline-offset: calc(0.75 * var(--space-unit));
+    outline-offset: calc(0.5 * var(--space-unit));
   }
 }
 
@@ -26,35 +26,37 @@
 .btn--secondary,
 .btn--ghost {
   @extend %btn-size-standard;
-  padding: 0 calc(2.5 * var(--space-unit));
+
+  color: var(--colour-grey-80);
+  padding: var(--space-unit) calc(2 * var(--space-unit));
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: var(--colour-grey-80);
+  }
+}
+
+.btn--primary,
+.btn--secondary {
+  &[disabled] {
+    background-color: var(--colour-grey-10);
+  }
 }
 
 .btn--primary {
-  background-color: var(--link-colour);
-  color: var(--colour-white);
+  background-color: var(--colour-amber-30);
 
   &:hover {
-    background-color: var(--link-colour-hover);
-    color: var(--colour-white);
+    background-color: var(--colour-amber-20);
   }
 
-  &:focus {
-    background-color: var(--link-colour);
-    color: var(--colour-white);
-  }
-
+  &:focus,
   &:active {
-    background-color: var(--link-colour-active);
-    color: var(--colour-white);
-  }
-
-  &[disabled] {
-    background-color: var(--colour-grey-20);
+    background-color: var(--colour-amber-30);
   }
 }
 
-.btn--secondary,
-.btn--ghost,
 .btn--link {
   color: var(--link-colour);
 
@@ -67,55 +69,57 @@
   }
 }
 
-.btn--secondary,
-.btn--ghost {
-  border: 1px solid var(--link-colour-active);
+.btn--secondary {
+  background-color: var(--colour-amber-20);
 
   &:hover {
-    border-color: var(--link-colour);
+    background-color: var(--colour-amber-10);
   }
 
+  &:focus,
   &:active {
-    border-color: var(--link-colour-active);
-  }
-
-  &[disabled] {
-    border-color: var(--link-colour-disabled);
+    background-color: var(--colour-amber-20);
   }
 }
 
-.btn--secondary {
+.btn--ghost {
   background-color: var(--colour-white);
 
-  &:active {
-    background-color: var(--colour-blue-10);
+  &:hover {
+    background-color: var(--colour-amber-20);
   }
 
+  &:focus,
   &[disabled] {
-    background-color: var(--colour-grey-20);
+    background-color: var(--colour-white);
+  }
+
+  &:active {
+    background-color: var(--colour-amber-10);
+  }
+
+  .btn__text {
+    border-bottom: 1px solid var(--colour-blue-80);
+    transition: ease 0.4s;
+    transition-property: border-bottom-color;
+  }
+
+  &:hover .btn__text,
+  &:active .btn__text,
+  &[disabled] .btn__text {
+    border-bottom-color: transparent;
   }
 }
 
 .btn__icon--left {
   margin-left: calc(-0.5 * var(--space-unit));
-  margin-right: var(--space-unit);
+  margin-right: calc(1.5 * var(--space-unit));
 }
 
 .btn__icon--right {
-  margin-left: var(--space-unit);
+  margin-left: calc(1.5 * var(--space-unit));
   margin-right: calc(-0.5 * var(--space-unit));
 }
-
-.btn--link {
-  .btn__icon--left {
-    margin-right: calc(1.5 * var(--space-unit));
-  }
-
-  .btn__icon--right {
-    margin-left: calc(1.5 * var(--space-unit));
-  }
-}
-
 
 // Call To Action wrapper styles
 

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -74,7 +74,7 @@
   background-color: transparent;
 
   &:hover {
-    background-color: var(--colour-amber-20);
+    background-color: var(--colour-amber-05);
   }
 
   &:focus,
@@ -85,18 +85,18 @@
   &:active {
     background-color: var(--colour-amber-10);
   }
+}
 
-  .btn__text {
-    border-bottom: 1px solid var(--colour-grey-80);
-    transition: ease 0.4s;
-    transition-property: border-bottom-color;
-  }
+.btn--tertiary .btn__text {
+  border-bottom: 1px solid var(--colour-grey-80);
+  transition: ease 0.4s;
+  transition-property: border-bottom-color;
+}
 
-  &:hover .btn__text,
-  &:active .btn__text,
-  &[disabled] .btn__text {
-    border-bottom-color: transparent;
-  }
+.btn--tertiary:hover .btn__text,
+.btn--tertiary:active .btn__text,
+.btn--tertiary[disabled] .btn__text {
+  border-bottom-color: transparent;
 }
 
 .btn--link {

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -100,7 +100,7 @@
 }
 
 .btn--link {
-  @include animated-link($selector: '.btn__text');
+  @include animated-link($child-selector: '.btn__text');
 }
 
 .btn__icon--left {

--- a/src/components/CTALink/_cta-link.scss
+++ b/src/components/CTALink/_cta-link.scss
@@ -10,12 +10,15 @@
   @extend %anchor-inherit;
   @include animated-link($selector: '.btn__text');
 
-  align-items: center;
-  display: inline-flex;
+  display: block;
   line-height: var(--body-line-height);
   margin-right: calc(6 * var(--space-unit));
   position: relative;
-  text-decoration: none;
+
+  @include mq(xs) {
+    align-items: center;
+    display: inline-flex;
+  }
 
   @include hocus {
     .btn__icon {

--- a/src/components/CTALink/_cta-link.scss
+++ b/src/components/CTALink/_cta-link.scss
@@ -8,10 +8,9 @@
 
 .cc-cta-link {
   @extend %anchor-inherit;
-  @include animated-underline(1px);
+  @include animated-link($selector: '.btn__text');
 
   align-items: center;
-  color: var(--colour-grey-80);
   display: inline-flex;
   line-height: var(--body-line-height);
   margin-right: calc(6 * var(--space-unit));

--- a/src/components/CTALink/_cta-link.scss
+++ b/src/components/CTALink/_cta-link.scss
@@ -8,7 +8,7 @@
 
 .cc-cta-link {
   @extend %anchor-inherit;
-  @include animated-link($selector: '.btn__text');
+  @include animated-link($child-selector: '.btn__text');
 
   display: block;
   line-height: var(--body-line-height);

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -73,7 +73,7 @@ export const Card = ({
         )}
         <h3 className="cc-card__title">
           <a href={href} className="cc-card__link" target="_self">
-            {title}
+            <span>{title}</span>
           </a>
         </h3>
         {isHorizontal && (authors || date) && (

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -73,7 +73,7 @@ export const Card = ({
         )}
         <h3 className="cc-card__title">
           <a href={href} className="cc-card__link" target="_self">
-            <span>{title}</span>
+            {title}
           </a>
         </h3>
         {isHorizontal && (authors || date) && (

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -106,7 +106,7 @@
 
 .cc-card__link {
   @extend %list-item-link;
-  @include animated-link;
+  @include animated-link($selector: 'span');
   display: block;
 
   &:before {

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -105,9 +105,7 @@
 }
 
 .cc-card__link {
-  @extend %list-item-link;
-  @include animated-link($selector: 'span');
-  display: block;
+  @include animated-link;
 
   &:before {
     bottom: 0;

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -106,6 +106,7 @@
 
 .cc-card__link {
   @extend %list-item-link;
+  @include animated-link;
   display: block;
 
   &:before {

--- a/src/components/Contact/_contact.scss
+++ b/src/components/Contact/_contact.scss
@@ -63,7 +63,7 @@
 
 .cc-contact__link {
   //@extend %anchor-base;
-  @include animated-double-underline;
+  @include animated-link;
 }
 
 .cc-contact__link-icon {

--- a/src/components/Contact/_contact.scss
+++ b/src/components/Contact/_contact.scss
@@ -62,7 +62,6 @@
 }
 
 .cc-contact__link {
-  //@extend %anchor-base;
   @include animated-link;
 }
 

--- a/src/components/Contact/_contact.scss
+++ b/src/components/Contact/_contact.scss
@@ -62,8 +62,8 @@
 }
 
 .cc-contact__link {
-  @extend %anchor-base;
-  text-decoration: none;
+  //@extend %anchor-base;
+  @include animated-double-underline;
 }
 
 .cc-contact__link-icon {

--- a/src/components/CookieMessage/CookieMessage.tsx
+++ b/src/components/CookieMessage/CookieMessage.tsx
@@ -36,7 +36,7 @@ export const CookieMessage = ({
         <Button
           className="cookie-message__button"
           href="/cookies/config"
-          variant="ghost"
+          variant="tertiary"
         >
           Manage preferences
         </Button>

--- a/src/components/CookieMessage/_cookie-message.scss
+++ b/src/components/CookieMessage/_cookie-message.scss
@@ -33,7 +33,7 @@
 }
 
 .cookie-message__text-link {
-  color: var(--colour-black);
+  @include animated-link;
 }
 
 .cookie-message__buttons {

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -124,8 +124,6 @@
    */
   .cc-featured-promo__figure:hover + .cc-featured-promo__body &,
   .cc-featured-promo__figure:focus + .cc-featured-promo__body & {
-    background-image: linear-gradient(transparent, transparent), linear-gradient(var(--colour-amber-30), var(--colour-amber-30));
-    background-position: left calc(100% - 1px);
-    background-size: 0 1px, 100% 3px;
+    @include hover-underline;
   }
 }

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -100,7 +100,7 @@
 .cc-featured-promo__title {
   @extend %heading-base;
   @extend %heading-large;
-  @include heading-fancy;
+  @include heading-fancy($space-above: var(--space-lg));
 }
 
 .cc-featured-promo__date {
@@ -113,7 +113,7 @@
 .cc-featured-promo__link {
   @extend %anchor-inherit;
   @extend %heading-large;
-  @include animated-underline;
+  @include animated-double-underline;
 
   font-weight: normal;
   line-height: var(--body-line-height);
@@ -124,7 +124,8 @@
    */
   .cc-featured-promo__figure:hover + .cc-featured-promo__body &,
   .cc-featured-promo__figure:focus + .cc-featured-promo__body & {
-    background-size: 100% 2px;
+    background-size: 100% 3px;
+    border-bottom-color: transparent;
     text-decoration: none;
     transition-timing-function: var(--transition-timing-function-in);
   }

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -113,7 +113,7 @@
 .cc-featured-promo__link {
   @extend %anchor-inherit;
   @extend %heading-large;
-  @include animated-double-underline;
+  @include animated-link;
 
   font-weight: normal;
   line-height: var(--body-line-height);
@@ -124,9 +124,8 @@
    */
   .cc-featured-promo__figure:hover + .cc-featured-promo__body &,
   .cc-featured-promo__figure:focus + .cc-featured-promo__body & {
-    background-size: 100% 3px;
-    border-bottom-color: transparent;
-    text-decoration: none;
-    transition-timing-function: var(--transition-timing-function-in);
+    background-image: linear-gradient(transparent, transparent), linear-gradient(var(--colour-amber-30), var(--colour-amber-30));
+    background-position: left calc(100% - 1px);
+    background-size: 0 1px, 100% 3px;
   }
 }

--- a/src/components/FileDownload/FileDownload.tsx
+++ b/src/components/FileDownload/FileDownload.tsx
@@ -38,7 +38,7 @@ export const FileDownload = ({
         download
         href={href}
       >
-        <span>{label}</span>
+        {label}
         <VisuallyHidden>{` ${name}`}</VisuallyHidden>
       </a>
       <span className="cc-file-download__meta">

--- a/src/components/FileDownload/FileDownload.tsx
+++ b/src/components/FileDownload/FileDownload.tsx
@@ -38,7 +38,7 @@ export const FileDownload = ({
         download
         href={href}
       >
-        {label}
+        <span>{label}</span>
         <VisuallyHidden>{` ${name}`}</VisuallyHidden>
       </a>
       <span className="cc-file-download__meta">

--- a/src/components/FileDownload/_file-download.scss
+++ b/src/components/FileDownload/_file-download.scss
@@ -1,5 +1,6 @@
 .cc-file-download__link {
   @extend %anchor-base;
+  @include animated-link;
   margin-right: var(--space-xs);
 }
 

--- a/src/components/FileInput/FileInput.tsx
+++ b/src/components/FileInput/FileInput.tsx
@@ -20,7 +20,7 @@ type FileInputProps = {
   handleChange?: (event: React.FormEvent<HTMLInputElement>) => void;
   tabIndex?: number;
   textClassName?: string;
-  variant?: 'primary' | 'secondary' | 'ghost' | 'unstyled';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'unstyled';
 };
 
 export const FileInput = forwardRef(

--- a/src/components/FileInput/_file-input.scss
+++ b/src/components/FileInput/_file-input.scss
@@ -46,7 +46,7 @@
     border-color: var(--link-colour-disabled);
   }
 
-  + .btn--ghost {
+  + .btn--tertiary {
     border-color: var(--link-colour-disabled);
   }
 }

--- a/src/components/Footer/FooterNewsletter/_footer-newsletter.scss
+++ b/src/components/Footer/FooterNewsletter/_footer-newsletter.scss
@@ -26,12 +26,10 @@
     color: var(--colour-white);
   }
 
+  a:hover,
   a:focus,
-  a:hover {
-    color: var(--colour-blue-40);
+  a:active {
+    color: var(--colour-white);
   }
 
-  a:active {
-    color: var(--colour-blue-20);
-  }
 }

--- a/src/components/FormField/_form-field.scss
+++ b/src/components/FormField/_form-field.scss
@@ -8,4 +8,9 @@
 
 .cc-form-field {
   margin-bottom: var(--space-lg);
+
+  a {
+    @include animated-link;
+    font-weight: 500;
+  }
 }

--- a/src/components/FullWidthPromo/_full-width-promo.scss
+++ b/src/components/FullWidthPromo/_full-width-promo.scss
@@ -68,7 +68,7 @@
 
 .cc-full-width-promo__title-link {
   @extend %anchor-inherit;
-  @include animated-double-underline;
+  @include animated-link;
 }
 
 .cc-full-width-promo__meta {

--- a/src/components/FullWidthPromo/_full-width-promo.scss
+++ b/src/components/FullWidthPromo/_full-width-promo.scss
@@ -61,14 +61,14 @@
 
 .cc-full-width-promo__title {
   @extend %heading-display;
-  @include heading-fancy;
+  @include heading-fancy($space-above: var(--space-lg));
   font-weight: normal;
   margin-top: 0;
 }
 
 .cc-full-width-promo__title-link {
   @extend %anchor-inherit;
-  @include animated-underline;
+  @include animated-double-underline;
 }
 
 .cc-full-width-promo__meta {

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -109,9 +109,7 @@
    */
   .cc-image-card__figure:hover + .cc-image-card__body &,
   .cc-image-card__figure:focus + .cc-image-card__body & {
-    background-image: linear-gradient(transparent, transparent), linear-gradient(var(--colour-amber-30), var(--colour-amber-30));
-    background-position: left calc(100% - 1px);
-    background-size: 0 1px, 100% 3px;
+    @include hover-underline;
   }
 }
 

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -47,15 +47,8 @@
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: calc(0.5 * var(--space-unit));
-
-  @include mq(sm) {
-    margin-bottom: calc(1.5 * var(--space-unit));
-  }
-
-  @include mq(md) {
-    margin-bottom: calc(2 * var(--space-unit));
-  }
+  margin-bottom: var(--space-md);
+  margin-top: var(--space-md);
 }
 
 .cc-image-card__meta-item {
@@ -102,17 +95,13 @@
   @extend %heading-large;
 
   font-weight: normal;
-  margin-bottom: var(--space-unit);
+  margin-bottom: var(--space-lg);
   margin-top: 0;
-
-  @include mq(sm) {
-    margin-bottom: calc(2 * var(--space-unit));
-  }
 }
 
 .cc-image-card__link {
   @extend %anchor-inherit;
-  @include animated-underline;
+  @include animated-double-underline;
 
   /**
    * Imitate the hover state when a user hovers over the image of
@@ -120,7 +109,8 @@
    */
   .cc-image-card__figure:hover + .cc-image-card__body &,
   .cc-image-card__figure:focus + .cc-image-card__body & {
-    background-size: 100% 2px;
+    background-size: 100% 3px;
+    border-bottom-color: transparent;
     text-decoration: none;
     transition-timing-function: var(--transition-timing-function-in);
   }

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -101,7 +101,7 @@
 
 .cc-image-card__link {
   @extend %anchor-inherit;
-  @include animated-double-underline;
+  @include animated-link;
 
   /**
    * Imitate the hover state when a user hovers over the image of
@@ -109,10 +109,9 @@
    */
   .cc-image-card__figure:hover + .cc-image-card__body &,
   .cc-image-card__figure:focus + .cc-image-card__body & {
-    background-size: 100% 3px;
-    border-bottom-color: transparent;
-    text-decoration: none;
-    transition-timing-function: var(--transition-timing-function-in);
+    background-image: linear-gradient(transparent, transparent), linear-gradient(var(--colour-amber-30), var(--colour-amber-30));
+    background-position: left calc(100% - 1px);
+    background-size: 0 1px, 100% 3px;
   }
 }
 

--- a/src/components/ImageCardWithCTA/_image-card-with-cta.scss
+++ b/src/components/ImageCardWithCTA/_image-card-with-cta.scss
@@ -83,9 +83,7 @@
    */
   .cc-image-card-with-cta__figure:hover + .cc-image-card-with-cta__body &,
   .cc-image-card-with-cta__figure:focus + .cc-image-card-with-cta__body & {
-    background-image: linear-gradient(transparent, transparent), linear-gradient(var(--colour-amber-30), var(--colour-amber-30));
-    background-position: left calc(100% - 1px);
-    background-size: 0 1px, 100% 3px;
+    @include hover-underline;
   }
 }
 

--- a/src/components/ImageCardWithCTA/_image-card-with-cta.scss
+++ b/src/components/ImageCardWithCTA/_image-card-with-cta.scss
@@ -75,7 +75,7 @@
 
 .cc-image-card-with-cta__link {
   @extend %anchor-inherit;
-  @include animated-double-underline;
+  @include animated-link;
 
   /**
    * Imitate the hover state when a user hovers over the image of
@@ -83,10 +83,9 @@
    */
   .cc-image-card-with-cta__figure:hover + .cc-image-card-with-cta__body &,
   .cc-image-card-with-cta__figure:focus + .cc-image-card-with-cta__body & {
-    background-size: 100% 3px;
-    border-bottom-color: transparent;
-    text-decoration: none;
-    transition-timing-function: var(--transition-timing-function-in);
+    background-image: linear-gradient(transparent, transparent), linear-gradient(var(--colour-amber-30), var(--colour-amber-30));
+    background-position: left calc(100% - 1px);
+    background-size: 0 1px, 100% 3px;
   }
 }
 

--- a/src/components/ImageCardWithCTA/_image-card-with-cta.scss
+++ b/src/components/ImageCardWithCTA/_image-card-with-cta.scss
@@ -67,7 +67,7 @@
 .cc-image-card-with-cta__title {
   @extend %heading-base;
   @extend %heading-large;
-  @include heading-fancy;
+  @include heading-fancy($space-above: var(--space-lg));
 
   font-weight: normal;
   letter-spacing: 0;
@@ -75,7 +75,7 @@
 
 .cc-image-card-with-cta__link {
   @extend %anchor-inherit;
-  @include animated-underline;
+  @include animated-double-underline;
 
   /**
    * Imitate the hover state when a user hovers over the image of
@@ -83,7 +83,8 @@
    */
   .cc-image-card-with-cta__figure:hover + .cc-image-card-with-cta__body &,
   .cc-image-card-with-cta__figure:focus + .cc-image-card-with-cta__body & {
-    background-size: 100% 2px;
+    background-size: 100% 3px;
+    border-bottom-color: transparent;
     text-decoration: none;
     transition-timing-function: var(--transition-timing-function-in);
   }

--- a/src/components/InpageNav/InpageNav.tsx
+++ b/src/components/InpageNav/InpageNav.tsx
@@ -36,7 +36,7 @@ export const InpageNav = ({
         return (
           <li key={`anchor-link-${id}`} className="cc-inpage-nav__item">
             <a className={linkClassNames} href={`#${id}`}>
-              {title}
+              <span>{title}</span>
             </a>
           </li>
         );
@@ -44,7 +44,7 @@ export const InpageNav = ({
       {hasBackToTop && (
         <li className="cc-inpage-nav__item cc-inpage-nav__item--top">
           <a className="cc-inpage-nav__link" href={backToTopHref}>
-            {backToTopText}
+            <span>{backToTopText}</span>
           </a>
         </li>
       )}

--- a/src/components/InpageNav/_inpage-nav.scss
+++ b/src/components/InpageNav/_inpage-nav.scss
@@ -53,7 +53,7 @@
 }
 
 .cc-inpage-nav__link {
-  @include animated-link($selector: 'span');
+  @include animated-link($child-selector: 'span');
 
   border-left: 4px solid transparent;
   display: block;

--- a/src/components/InpageNav/_inpage-nav.scss
+++ b/src/components/InpageNav/_inpage-nav.scss
@@ -53,7 +53,7 @@
 }
 
 .cc-inpage-nav__link {
-  @include animated-link;
+  @include animated-link($selector: 'span');
 
   border-left: 4px solid transparent;
   display: block;
@@ -69,7 +69,7 @@
     padding-left: var(--space-unit);
 
     span { /* stylelint-disable-line max-nesting-depth */
-      border-bottom-color: transparent;
+      background-image: none;
       font-weight: 500;
     }
   }

--- a/src/components/InpageNav/_inpage-nav.scss
+++ b/src/components/InpageNav/_inpage-nav.scss
@@ -53,8 +53,9 @@
 }
 
 .cc-inpage-nav__link {
-  border-left: 2px solid transparent;
-  color: var(--colour-grey-60);
+  @include animated-link;
+
+  border-left: 4px solid transparent;
   display: block;
   margin-bottom: calc(0.5 * var(--space-unit));
   padding: calc(0.25 * var(--space-unit)) var(--space-unit);
@@ -62,18 +63,15 @@
   transition: ease var(--transition-duration-fast);
   transition-property: border, color, padding;
 
-  @include hocus {
-    color: var(--colour-blue-70);
-  }
-
-  &:active {
-    color: var(--colour-blue-50);
-  }
-
   &.is-active {
-    border-left-color: var(--colour-blue-60);
+    border-left-color: var(--colour-amber-30);
     color: var(--colour-grey-80);
     padding-left: var(--space-unit);
+
+    span { /* stylelint-disable-line max-nesting-depth */
+      border-bottom-color: transparent;
+      font-weight: 500;
+    }
   }
 }
 

--- a/src/components/Listing/_listing.scss
+++ b/src/components/Listing/_listing.scss
@@ -30,7 +30,7 @@
 
 .cc-listing__link {
   @extend %anchor-base;
-  @include animated-link($selector: '.cc-listing__link-text');
+  @include animated-link($child-selector: '.cc-listing__link-text');
 
   display: block;
   line-height: var(--body-line-height);

--- a/src/components/Listing/_listing.scss
+++ b/src/components/Listing/_listing.scss
@@ -57,7 +57,7 @@
   //top: 50%;
   //transform: translateY(-50%);
   transform: translateY(20px);
-  width: 0.375em;
+  width: 0.5em;
 }
 
 .cc-listing__link-icon--download {

--- a/src/components/Listing/_listing.scss
+++ b/src/components/Listing/_listing.scss
@@ -53,10 +53,7 @@
   margin-left: auto;
   position: absolute;
   right: var(--space-unit);
-  top: 0;
-  //top: 50%;
-  //transform: translateY(-50%);
-  transform: translateY(20px);
+  top: calc(2.5 * var(--space-unit)); // 20px
   width: 0.5em;
 }
 

--- a/src/components/Listing/_listing.scss
+++ b/src/components/Listing/_listing.scss
@@ -21,20 +21,20 @@
 
 .cc-listing {
   @extend %list-clean;
-  border-bottom: 1px solid var(--colour-grey-10);
   width: 100%;
 }
 
 .cc-listing__item {
-  border-top: 1px solid var(--colour-grey-10);
   display: block;
 }
 
 .cc-listing__link {
   @extend %anchor-base;
+  @include animated-link($selector: '.cc-listing__link-text');
+
   display: block;
   line-height: var(--body-line-height);
-  padding: var(--space-unit) calc(5 * var(--space-unit)) var(--space-unit) 0;
+  padding: calc(2 * var(--space-unit)) calc(5 * var(--space-unit)) calc(2 * var(--space-unit)) 0;
   position: relative;
   text-decoration: none;
 }
@@ -53,8 +53,10 @@
   margin-left: auto;
   position: absolute;
   right: var(--space-unit);
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
+  //top: 50%;
+  //transform: translateY(-50%);
+  transform: translateY(20px);
   width: 0.375em;
 }
 

--- a/src/components/Media/_media.scss
+++ b/src/components/Media/_media.scss
@@ -37,6 +37,10 @@
   line-height: var(--body-line-height);
   margin-top: calc(2 * var(--space-unit));
   padding: calc(0.25 * var(--space-unit)) 0 calc(0.25 * var(--space-unit)) calc(2 * var(--space-unit));
+
+  a {
+    @include animated-link;
+  }
 }
 
 .cc-media--wide__caption {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -12,7 +12,7 @@ type ModalProps = {
     href?: string;
     text?: string;
     type: 'agree' | 'cancel' | 'link';
-    variant: 'link' | 'primary' | 'secondary' | 'ghost' | 'unstyled';
+    variant: 'link' | 'primary' | 'secondary' | 'tertiary' | 'unstyled';
   }[];
   className?: string;
   onAccept: () => void;

--- a/src/components/NewsletterForm/NewsletterFormFooter.tsx
+++ b/src/components/NewsletterForm/NewsletterFormFooter.tsx
@@ -11,8 +11,9 @@ export const NewsletterFormFooter = () => (
       We use a third party provider, Dotmailer, to deliver our newsletters. For
       information about how we handle your data, please read our{' '}
       <a
-        href="/about-us/governance/privacy-and-terms"
         aria-label="We use a third party provider, Dotdigital, to deliver our newsletters. For information about how we handle your data, please read our privacy notice"
+        className="newsletter-form__link"
+        href="/about-us/governance/privacy-and-terms"
       >
         privacy notice
       </a>

--- a/src/components/NewsletterForm/_newsletter-form.scss
+++ b/src/components/NewsletterForm/_newsletter-form.scss
@@ -64,6 +64,10 @@
   }
 }
 
+.newsletter-form__link {
+  @include animated-link($hover-colour: var(--colour-white), $underline-colour: var(--colour-white));
+}
+
 /* Errors */
 
 .newsletter-form__item-error {

--- a/src/components/NewsletterForm/fetch-newsletter-response.ts
+++ b/src/components/NewsletterForm/fetch-newsletter-response.ts
@@ -7,9 +7,9 @@ export const fetchNewsletterResponse = async (
   const requestOptions = {
     method: 'POST',
     headers: {
-      'Accept': 'application/json',
+      Accept: 'application/json',
       'Content-Type': 'application/json'
-  },
+    },
     body: JSON.stringify({
       email,
       type,

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -38,11 +38,20 @@
 .cc-pagination__prev-link,
 .cc-pagination__link {
   align-items: center;
+  color: var(--colour-blue-60);
   cursor: pointer;
   display: flex;
   font-size: var(--body-sm);
   padding: var(--space-unit);
   text-decoration: none;
+
+  @include hocus {
+    color: var(--colour-blue-70);
+  }
+
+  &:active {
+    color: var(--colour-blue-50);
+  }
 }
 
 .cc-pagination__next,

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -9,8 +9,6 @@
 .cc-rich-text {
   // ensure extra long words are wrapped to prevent overlap or horizontal scroll
   overflow-wrap: break-word;
-  // ensure wide table data can be seen using horizontal scroll
-  overflow-x: auto;
   word-wrap: break-word;
 
   h2 {

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -48,6 +48,11 @@
     margin-bottom: calc(2 * var(--space-unit));
   }
 
+  a {
+    @include animated-double-underline;
+    font-weight: 500;
+  }
+
   table {
     border-collapse: collapse;
     caption-side: top;
@@ -107,6 +112,11 @@
 
   p {
     @extend %body-regular;
+  }
+
+  a {
+    @include animated-double-underline;
+    font-weight: 500;
   }
 
   ol,

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -46,11 +46,6 @@
     margin-bottom: calc(2 * var(--space-unit));
   }
 
-  a {
-    @include animated-link;
-    font-weight: 500;
-  }
-
   table {
     border-collapse: collapse;
     caption-side: top;
@@ -112,11 +107,6 @@
     @extend %body-regular;
   }
 
-  a {
-    @include animated-link;
-    font-weight: 500;
-  }
-
   ol,
   ul {
     @extend %list-base;
@@ -147,4 +137,10 @@
 .cc-rich-text > :last-child,
 .cc-rich-text-snippet > :last-child {
   margin-bottom: 0;
+}
+
+.cc-rich-text a,
+.cc-rich-text-snippet a {
+  @include animated-link;
+  font-weight: 500;
 }

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -139,8 +139,10 @@
   margin-bottom: 0;
 }
 
-.cc-rich-text a,
-.cc-rich-text-snippet a {
+/* stylelint-disable selector-no-qualifying-type */
+.cc-rich-text a[href],
+.cc-rich-text-snippet a[href] {
   @include animated-link;
   font-weight: 500;
 }
+/* stylelint-enable selector-no-qualifying-type */

--- a/src/components/RichText/_rich-text.scss
+++ b/src/components/RichText/_rich-text.scss
@@ -49,7 +49,7 @@
   }
 
   a {
-    @include animated-double-underline;
+    @include animated-link;
     font-weight: 500;
   }
 
@@ -115,7 +115,7 @@
   }
 
   a {
-    @include animated-double-underline;
+    @include animated-link;
     font-weight: 500;
   }
 

--- a/src/components/SearchForm/_search-form.scss
+++ b/src/components/SearchForm/_search-form.scss
@@ -45,7 +45,6 @@
 }
 
 .search-form__btn-submit .icon {
-  color: var(--colour-white);
   margin-right: 0;
 }
 

--- a/src/components/SiteAlert/SiteAlert.test.tsx
+++ b/src/components/SiteAlert/SiteAlert.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { boolean } from '@storybook/addon-knobs';
 
 import SiteAlert from './SiteAlert';
 

--- a/src/components/SiteAlert/SiteAlert.tsx
+++ b/src/components/SiteAlert/SiteAlert.tsx
@@ -34,7 +34,7 @@ export const SiteAlert = ({
             className="site-alert__link no-external-marker"
             tabIndex={tabIndex}
           >
-            {text}
+            <span className="site-alert__link-text">{text}</span>
             <Icon name="arrow" />
           </a>
         ) : (

--- a/src/components/SiteAlert/_site-alert.scss
+++ b/src/components/SiteAlert/_site-alert.scss
@@ -47,7 +47,7 @@
 }
 
 .site-alert__link {
-  @include animated-link($hover-colour: var(--colour-grey-80), $selector: '.site-alert__link-text');
+  @include animated-link($hover-colour: var(--colour-grey-80), $child-selector: '.site-alert__link-text');
   align-items: center;
   color: var(--colour-grey-80);
   display: flex;

--- a/src/components/SiteAlert/_site-alert.scss
+++ b/src/components/SiteAlert/_site-alert.scss
@@ -47,6 +47,7 @@
 }
 
 .site-alert__link {
+  @include animated-link($hover-colour: var(--colour-grey-80), $selector: '.site-alert__link-text');
   align-items: center;
   color: var(--colour-grey-80);
   display: flex;
@@ -62,13 +63,6 @@
       margin-left: calc(2 * var(--space-unit));
     }
   }
-}
-
-.site-alert__link.site-alert__link:active,
-.site-alert__link.site-alert__link:focus,
-.site-alert__link.site-alert__link:hover {
-  color: var(--colour-grey-80);
-  text-decoration: none;
 }
 
 .site-alert__text {

--- a/src/components/TextCard/_text-card.scss
+++ b/src/components/TextCard/_text-card.scss
@@ -7,12 +7,13 @@
 
 .cc-text-card__title {
   font-size: var(--body-md);
-  margin-bottom: var(--space-xs);
-  margin-top: var(--space-xs);
+  margin-bottom: var(--space-md);
+  margin-top: 0;
 }
 
 .cc-text-card__link {
-  @extend %list-item-link;
+  //@extend %list-item-link;
+  @include animated-double-underline;
 }
 
 .cc-text-card__description,
@@ -21,14 +22,28 @@
   margin-top: 0;
 }
 
+.cc-text-card__description a {
+  @include animated-double-underline;
+}
+
 .cc-text-card__description + .cc-text-card__description {
-  margin-top: var(--space-sm);
+  margin-top: var(--space-md);
 }
 
 .cc-text-card__meta {
   font-size: var(--body-sm);
-  line-height: 1.57143;
-  margin-bottom: var(--space-xs);
+  line-height: var(--body-line-height);
+  margin-bottom: var(--space-md);
+}
+
+.cc-text-card__meta-label + .cc-text-card__date {
+  margin-left: var(--space-xs);
+
+  &:before {
+    color: var(--colour-amber-30);
+    content: '/';
+    margin-right: var(--space-unit);
+  }
 }
 
 .cc-text-card__closing-date {
@@ -51,7 +66,7 @@
 }
 
 .cc-text-card__file-meta {
-  margin-bottom: var(--space-xs);
+  margin-bottom: var(--space-md);
 }
 
 .cc-text-card__file-meta-download {

--- a/src/components/TextCard/_text-card.scss
+++ b/src/components/TextCard/_text-card.scss
@@ -12,8 +12,7 @@
 }
 
 .cc-text-card__link {
-  //@extend %list-item-link;
-  @include animated-double-underline;
+  @include animated-link;
 }
 
 .cc-text-card__description,
@@ -23,7 +22,7 @@
 }
 
 .cc-text-card__description a {
-  @include animated-double-underline;
+  @include animated-link;
 }
 
 .cc-text-card__description + .cc-text-card__description {

--- a/src/components/Video/_video.scss
+++ b/src/components/Video/_video.scss
@@ -29,4 +29,8 @@
 .cc-video__caption {
   font-size: var(--body-xs);
   margin-bottom: 0;
+
+  a {
+    @include animated-double-underline;
+  }
 }

--- a/src/components/Video/_video.scss
+++ b/src/components/Video/_video.scss
@@ -31,6 +31,6 @@
   margin-bottom: 0;
 
   a {
-    @include animated-double-underline;
+    @include animated-link;
   }
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8554

Link to designs: https://www.sketch.com/s/fdfb45f3-3e86-49d2-9f06-332acc86024c

### My approach

I added new link styles directly to the components in CC, and I didn't add any global styles to anchor in CR.

### This PR

- adds new link and button styles
- adds `animated-link` mixin which can handle two scenarios
   1. the regular anchor
   2. the anchor with children (adds the underline styles to chosen child)
- adds `u-animated-link` - I think it could be better to have a class which is available in CR (instead of copy-pase the whole mixin)
- removes `overflow-x` on RichText - if link was a last child within RichText it was showing the vertical scroll (due to adding padding-bottom to anchor)

### Test

Link to a QA branch: https://qa-8554-yellow-links.wellcome-corporate-fe.org.uk/

Sorry for a big PR, I hope looking at this page with components make it easier to see changes: https://qa-8554-yellow-links.wellcome-corporate-fe.org.uk/what-we-do/our-work/listing-options.

We can compare the changes to this link: https://develop.wellcome-corporate-fe.org.uk/what-we-do/our-work/listing-options
