### PR TITLE
8617 bug: link list incorrect markup

### DIFF
--- a/src/components/InfoBox/InfoBox.stories.tsx
+++ b/src/components/InfoBox/InfoBox.stories.tsx
@@ -40,10 +40,8 @@ const InfoBoxExample = () => {
           priority for G20 countries, philanthropy and the private sector.
         </p>`}
       </Text>
-      <Listing>
-        <Contact name="John Smith" />
-        <Contact name="Bertie Basset" />
-      </Listing>
+      <Contact name="John Smith" />
+      <Contact name="Bertie Basset" />
       <Listing>
         <ListingLink href="#1" title="Link 1 text" />
         <ListingLink href="#2" title="Link 2 text" />

--- a/src/components/Listing/Listing.tsx
+++ b/src/components/Listing/Listing.tsx
@@ -37,7 +37,7 @@ export const Listing = ({
   className,
   variant = 'link_list'
 }: ListingProps) => {
-  const Element = as;
+  const Element = variant === 'link_list' ? 'ul' : as;
   const classNames = cx(variantMapping[variant], {
     [`${className}`]: className
   });


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8617

### Context

List link markup was incorrect - it was displaying `<div>` instead of `<ul>`.

<img src="https://user-images.githubusercontent.com/10700103/119974084-2ae71700-bfac-11eb-96c6-51bed7a5bc2f.png" />

I have made a change based on assumption that `link_list` variant is wrapping the `<li>` elements.

I created a [page, where I listed the list variants](https://develop.wellcome-corporate-fe.org.uk/what-we-do/our-work/listing-options).

### This PR

- adds conditional to check if the `list_link` option was selected then use `<ul>` as a wrapper