### PR TITLE
4557 bug: fixes screen reader not able to read newsletter email name

### DIFF
--- a/src/components/Footer/FooterNewsletter/FooterNewsletter.tsx
+++ b/src/components/Footer/FooterNewsletter/FooterNewsletter.tsx
@@ -4,7 +4,10 @@ import NewsletterForm from 'NewsletterForm';
 
 export const FooterNewsletter = () => (
   <div className="footer-newsletter">
-    <NewsletterForm className="footer-newsletter__form">
+    <NewsletterForm
+      className="footer-newsletter__form"
+      emailInputId="footer-newsletter"
+    >
       <p className="footer-newsletter__intro">
         Get the latest news about Wellcome and the work we fund in a monthly
         email.

--- a/src/components/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/NewsletterForm/NewsletterForm.tsx
@@ -20,6 +20,7 @@ import NewsletterFormError from './NewsletterFormError';
 type NewsletterFormProps = {
   children?: React.ReactNode;
   className?: string;
+  emailInputId: string;
   type?: string;
   researchOption?: string;
 };
@@ -27,6 +28,7 @@ type NewsletterFormProps = {
 export const NewsletterForm = ({
   children,
   className,
+  emailInputId,
   researchOption,
   type
 }: NewsletterFormProps) => {
@@ -159,6 +161,7 @@ export const NewsletterForm = ({
             handleBlur={event => handleEmailBlur(event.currentTarget)}
             handleChange={event => handleEmailChange(event.currentTarget)}
             hasError={emailError}
+            id={emailInputId}
             value={email}
           />
           <NewsletterFormSubmit

--- a/src/components/NewsletterForm/NewsletterFormEmail.tsx
+++ b/src/components/NewsletterForm/NewsletterFormEmail.tsx
@@ -8,6 +8,7 @@ type NewsletterFormEmailProps = {
   handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
   handleChange?: (event: React.FormEvent<HTMLInputElement>) => void;
   hasError?: boolean | null;
+  id: string;
   value?: string;
 };
 
@@ -15,6 +16,7 @@ export const NewsletterFormEmail = ({
   handleBlur,
   handleChange,
   hasError,
+  id,
   value
 }: NewsletterFormEmailProps) => {
   const classNames = cx('newsletter-form__input', {
@@ -25,24 +27,26 @@ export const NewsletterFormEmail = ({
     <NewsletterFormItem hasError={hasError} type="email">
       <label
         className="newsletter-form__item-label newsletter-form__item-label--email"
-        htmlFor="email"
+        htmlFor={id}
       >
         Your email address
       </label>
       <input
+        autoComplete="email"
         className={classNames}
-        id="email"
+        id={id}
         name="email"
         onBlur={handleBlur}
         onChange={handleChange}
         required
+        spellCheck="false"
         type="email"
         value={value}
       />
       {hasError && (
         <div className="newsletter-form__item-error">
           <VisuallyHidden>
-            Error on the &quot;Your email address&quot; field
+            Error on the &quot;Your email address&quot; field.
           </VisuallyHidden>
           <span className="newsletter-form__item-error-text">
             Please provide a valid email address.

--- a/src/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup/NewsletterSignup.tsx
@@ -39,7 +39,11 @@ export const NewsletterSignup = ({
             &nbsp;
           </span>
         </h3>
-        <NewsletterForm className="newsletter__form" type={type}>
+        <NewsletterForm
+          className="newsletter__form"
+          emailInputId="newsletter-signup"
+          type={type}
+        >
           <div className="newsletter-signup__intro">
             <RichText>{intro}</RichText>
           </div>


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/4557

### Context

Screen readers couldn't read name of email address field in footer newsletter sign up. 

It was happening on the pages with both newsletter signup  and newsletter signup in the footer (i.e homepage). I think it was because both of the input fields have the same `id`.

After changing ids screen reader can read the newsletter email label: `Your email address`.

### This PR

- adds an id prop to `NewsletterFormEmail`
- adds an `emailInputId` to `NewsletterForm`
- adds `autocomplete` and `spellcheck` attributes as recommended by [gov.uk](https://design-system.service.gov.uk/patterns/email-addresses/)

