### PR TITLE
8686 task: adds TextInput storybook component

### DIFF
--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import FormField from 'FormField';
+import FormFieldError from 'FormFieldError';
+import Label from 'Label';
+
+import TextInput from './TextInput';
+
+const TextInputExample = () => {
+  const isDisabled = boolean('isDisabled', false);
+  const isInvalid = boolean('isInvalid', false);
+  const isRequired = boolean('isRequired', false);
+
+  return (
+    <TextInput
+      id="text-input"
+      isDisabled={isDisabled}
+      isInvalid={isInvalid}
+      isRequired={isRequired}
+      name="text-input"
+      type="text"
+    />
+  );
+};
+
+const TextInputFormFieldExample = () => {
+  const label = text('label', 'Input Label');
+  const isDisabled = boolean('isDisabled', false);
+  const isInvalid = boolean('isInvalid', false);
+  const isRequired = boolean('isRequired', false);
+
+  return (
+    <FormField>
+      <Label htmlFor="text-input" isDisabled={isDisabled} text={label} />
+      <TextInput
+        id="text-input"
+        isDisabled={isDisabled}
+        isInvalid={isInvalid}
+        isRequired={isRequired}
+        name="text-input"
+        type="text"
+      />
+      {isInvalid && (
+        <FormFieldError id="text-input-error" errors="This field is invalid" />
+      )}
+    </FormField>
+  );
+};
+
+const stories = storiesOf('TextInput', module);
+
+stories.add('Simple', TextInputExample);
+stories.add('Form Field (with label)', TextInputFormFieldExample);


### PR DESCRIPTION
# Context

I wanted to see what a TextInput looked like, and realised there wasn't a storybook component for it.

Resolves wellcometrust/corporate/issues/8686

# Description

This PR adds a storybook component file for TextInput:

- one example is a "basic" TextInput (no label)
- another example is the TextInput within a FormField (with sibling FormFieldError and Label)