### PR TITLE
8722 task: footer accessibility improvements

### DIFF
--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -11,6 +11,7 @@ type LogoProps = {
     path?: string;
   };
   fill?: string;
+  id?: string;
   title?: string;
 };
 
@@ -18,6 +19,7 @@ export const Logo = ({
   className,
   data: { viewBox, fillRule, path },
   fill,
+  id,
   title,
   ...otherProps
 }: LogoProps) => {
@@ -28,11 +30,11 @@ export const Logo = ({
       viewBox={viewBox}
       className={classNames}
       role="img"
-      aria-labelledby="logo-title"
+      aria-labelledby={id || null}
       preserveAspectRatio="xMinYMid"
       {...otherProps}
     >
-      {title && <title id="logo-title">{title}</title>}
+      {title && id && <title id={id}>{title}</title>}
       <path d={path} fill={fill} fillRule={fillRule} />
     </svg>
   );

--- a/src/components/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/NewsletterForm/NewsletterForm.tsx
@@ -134,7 +134,10 @@ export const NewsletterForm = ({
   return (
     // Show the success response if the submission has been sent
     responseSuccess ? (
-      <div className="newsletter-form__response-msg newsletter-form__response-msg--success">
+      <div
+        className="newsletter-form__response-msg newsletter-form__response-msg--success"
+        role="status"
+      >
         <p className="newsletter-form__response-msg-text">
           Thank you. If this is the first time you have subscribed to a
           newsletter from Wellcome, you will receive an email asking you to

--- a/src/components/NewsletterForm/NewsletterFormEmail.tsx
+++ b/src/components/NewsletterForm/NewsletterFormEmail.tsx
@@ -44,7 +44,7 @@ export const NewsletterFormEmail = ({
         value={value}
       />
       {hasError && (
-        <div className="newsletter-form__item-error">
+        <div className="newsletter-form__item-error" role="status">
           <VisuallyHidden>
             Error on the &quot;Your email address&quot; field.
           </VisuallyHidden>

--- a/src/components/NewsletterForm/NewsletterFormEmail.tsx
+++ b/src/components/NewsletterForm/NewsletterFormEmail.tsx
@@ -44,7 +44,7 @@ export const NewsletterFormEmail = ({
         value={value}
       />
       {hasError && (
-        <div className="newsletter-form__item-error" role="status">
+        <div className="newsletter-form__item-error">
           <VisuallyHidden>
             Error on the &quot;Your email address&quot; field.
           </VisuallyHidden>

--- a/src/components/NewsletterForm/NewsletterFormFooter.tsx
+++ b/src/components/NewsletterForm/NewsletterFormFooter.tsx
@@ -9,7 +9,6 @@ export const NewsletterFormFooter = () => (
       We use a third party provider, Dotdigital, to deliver our newsletters. For
       information about how we handle your data, please read our{' '}
       <a
-        aria-label="We use a third party provider, Dotdigital, to deliver our newsletters. For information about how we handle your data, please read our privacy notice."
         className="newsletter-form__link"
         href="/about-us/governance/privacy-and-terms"
       >

--- a/src/components/NewsletterForm/NewsletterFormResearchDropDown.tsx
+++ b/src/components/NewsletterForm/NewsletterFormResearchDropDown.tsx
@@ -22,7 +22,7 @@ export const NewsletterFormResearchDropDown = ({
       <select
         id="edit-research-options"
         name="research_options"
-        className="form-select"
+        className="cc-select"
         value={value}
         onChange={handleChange}
       >

--- a/src/components/NewsletterForm/_newsletter-form.scss
+++ b/src/components/NewsletterForm/_newsletter-form.scss
@@ -57,6 +57,10 @@
   }
 }
 
+.newsletter-form__item--dropdown {
+  flex-basis: 100%;
+}
+
 .newsletter-form__link {
   @include animated-link($hover-colour: var(--colour-white), $underline-colour: var(--colour-white));
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8722

### Context

Fixes issues found by accessibility audit:

- Newsletter sign up - incorrect use of aria label in 'privacy notice' link. Remove the aria-label as it is not required and causes duplication and confusion for screen reader users.
- Provide an alert so that blind users are aware of the thank you message that has been added to the page. This can be achieved by implementing `role="status"` on the containing `<div>`

### This PR

- removes aria-label
- adds `id` prop to Logo component
- adds role=status to thank you message
- updates styles for dropdown in the research newsletter signup

