### PR TITLE
8723 task: cookie banner accessibility updates

### DIFF
--- a/src/components/CookieMessage/CookieMessage.tsx
+++ b/src/components/CookieMessage/CookieMessage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Button from 'Button';
 import Icon from 'Icon';
+import VisuallyHidden from 'VisuallyHidden';
 
 type CookieMessageProps = {
   handleDismiss?: () => void;
@@ -14,7 +15,7 @@ export const CookieMessage = ({
 }: CookieMessageProps) => {
   return isActive ? (
     <div className="cookie-message">
-      <p className="cookie-message__heading">
+      <h2 className="cookie-message__heading">
         <Icon
           className="cookie-message__heading-icon"
           name="cookie"
@@ -22,7 +23,7 @@ export const CookieMessage = ({
           width="1.25rem"
         />
         Cookies
-      </p>
+      </h2>
       <p className="cookie-message__text">
         Wellcome uses cookies to improve your experience.{' '}
         <a
@@ -41,7 +42,7 @@ export const CookieMessage = ({
           Manage preferences
         </Button>
         <Button className="cookie-message__button" onClick={handleDismiss}>
-          Accept and close
+          Accept and close<VisuallyHidden> cookies banner</VisuallyHidden>
         </Button>
       </div>
     </div>

--- a/src/components/CookieMessage/_cookie-message.scss
+++ b/src/components/CookieMessage/_cookie-message.scss
@@ -17,6 +17,7 @@
 .cookie-message__heading {
   align-items: center;
   display: flex;
+  font-size: var(--body-md);
   font-weight: bold;
   line-height: var(--body-line-height);
   margin-bottom: var(--space-unit);


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8723

### Context

Accessibility audit recommendations on cookie banner:

- 'Cookies' title should be H2, not paragraph text styled as heading
- Descriptive labelling issue - 'Accept and close' button doesn't make sense out of context for screen readers. Add hidden additional information for screen readers to say 'Accept and close cookies banner' 

### This PR

- replaces `p` with `h2`
- adds visually hidden text to  'Accept and close' button