### PR TITLE
8724 task: adds missing fieldset for SidebarFilter

### DIFF
--- a/src/components/SidebarFilter/SidebarFilter.tsx
+++ b/src/components/SidebarFilter/SidebarFilter.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Button from 'Button';
 import Accordion, { AccordionItem } from 'Accordion/Accordion';
 import Checkbox from 'Checkbox';
+import FormFieldset from 'FormFieldset';
 import SkipLink from 'SkipLink';
 import VisuallyHidden from 'VisuallyHidden';
 
@@ -87,20 +88,29 @@ export const SidebarFilter = ({
         {tags.map(({ name, items }) => (
           <Accordion key={name} hasBorders variant="filter">
             <AccordionItem title={name}>
-              <ul className="cc-sidebar-filter__list">
-                {items.map(item => (
-                  <li className="cc-sidebar-filter__list-item" key={item.value}>
-                    <Checkbox
-                      checked={item.isActive}
-                      className="cc-sidebar-filter__checkbox"
-                      id={item.label}
-                      isDisabled={item.isDisabled}
-                      label={item.label}
-                      onChange={() => onChange(item.value)}
-                    />
-                  </li>
-                ))}
-              </ul>
+              <FormFieldset
+                className="cc-sidebar-filter__list-wrapper"
+                legend={name}
+                legendClassName="u-visually-hidden"
+              >
+                <ul className="cc-sidebar-filter__list">
+                  {items.map(item => (
+                    <li
+                      className="cc-sidebar-filter__list-item"
+                      key={item.value}
+                    >
+                      <Checkbox
+                        checked={item.isActive}
+                        className="cc-sidebar-filter__checkbox"
+                        id={item.label}
+                        isDisabled={item.isDisabled}
+                        label={item.label}
+                        onChange={() => onChange(item.value)}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              </FormFieldset>
             </AccordionItem>
           </Accordion>
         ))}

--- a/src/components/SidebarFilter/_sidebar-filter.scss
+++ b/src/components/SidebarFilter/_sidebar-filter.scss
@@ -50,6 +50,10 @@
   }
 }
 
+.cc-sidebar-filter__list-wrapper {
+  margin-bottom: 0;
+}
+
 .cc-sidebar-filter__list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8724


### Context

Accessibility audit:

-  Filter sets (e.g. 'article type' check boxes and 'topics' check boxes) should be grouped using a fieldset and legend (https://wellcome.org/news/all)

### This PR

- adds fieldset and legend to SidebarFilter
