### PR TITLE
8807 task: adds captionDisplay option to Image component

### DIFF
--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 
 import Image from './Image';
 import Readme from './Image.md';
@@ -9,12 +9,16 @@ const ImageExample = () => {
   const AltText = text('alt', 'Image alt text');
   const CaptionText = text('caption', 'Image caption');
   const CreditText = text('credit', 'Image credit');
+  const captionVariant = select('caption variant', ['below', 'right'], 'right');
+  const shouldHideCaption = boolean('should hide caption', false);
 
   return (
     <Image
       alt={AltText}
-      caption={CaptionText}
+      captionText={CaptionText}
+      captionVariant={captionVariant}
       credit={CreditText}
+      shouldHideCaption={shouldHideCaption}
       src="https://placehold.it/768x432&text=default+image+(768w)"
       srcSet="https://placehold.it/400x225 400w, https://placehold.it/768x432 768w, https://placehold.it/1024x576 1024w"
     />

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -5,11 +5,11 @@ import ImageElement from './ImageElement';
 
 type ImageProps = {
   alt: string;
-  caption?: string;
+  captionText?: string;
   captionVariant?: 'below' | 'right';
   credit?: string;
   className?: string;
-  hideCaption?: boolean;
+  shouldHideCaption?: boolean;
   licence?: string;
   sizes?: string;
   src: string;
@@ -21,23 +21,23 @@ const imageSizesDefault =
 
 export const Image = ({
   alt = '',
-  caption,
+  captionText,
   captionVariant = 'right',
   credit,
   className,
-  hideCaption,
   licence,
+  shouldHideCaption,
   sizes = imageSizesDefault,
   src,
   srcSet
 }: ImageProps) => (
   <Media
-    caption={caption}
+    caption={captionText}
     captionVariant={captionVariant}
     className={className}
     credit={credit}
-    hideCaption={hideCaption}
     licence={licence}
+    shouldHideCaption={shouldHideCaption}
   >
     <ImageElement alt={alt} sizes={srcSet && sizes} src={src} srcSet={srcSet} />
   </Media>

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -6,6 +6,7 @@ import ImageElement from './ImageElement';
 type ImageProps = {
   alt: string;
   caption?: string;
+  captionDisplay?: string;
   credit?: string;
   className?: string;
   licence?: string;
@@ -20,6 +21,7 @@ const imageSizesDefault =
 export const Image = ({
   alt = '',
   caption,
+  captionDisplay,
   credit,
   className,
   licence,
@@ -29,6 +31,7 @@ export const Image = ({
 }: ImageProps) => (
   <Media
     caption={caption}
+    captionDisplay={captionDisplay}
     className={className}
     credit={credit}
     licence={licence}

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -6,9 +6,10 @@ import ImageElement from './ImageElement';
 type ImageProps = {
   alt: string;
   caption?: string;
-  captionDisplay?: string;
+  captionVariant?: 'below' | 'right';
   credit?: string;
   className?: string;
+  hideCaption?: boolean;
   licence?: string;
   sizes?: string;
   src: string;
@@ -21,9 +22,10 @@ const imageSizesDefault =
 export const Image = ({
   alt = '',
   caption,
-  captionDisplay,
+  captionVariant = 'right',
   credit,
   className,
+  hideCaption,
   licence,
   sizes = imageSizesDefault,
   src,
@@ -31,9 +33,10 @@ export const Image = ({
 }: ImageProps) => (
   <Media
     caption={caption}
-    captionDisplay={captionDisplay}
+    captionVariant={captionVariant}
     className={className}
     credit={credit}
+    hideCaption={hideCaption}
     licence={licence}
   >
     <ImageElement alt={alt} sizes={srcSet && sizes} src={src} srcSet={srcSet} />

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -9,8 +9,8 @@ type ImageProps = {
   captionVariant?: 'below' | 'right';
   credit?: string;
   className?: string;
-  shouldHideCaption?: boolean;
   licence?: string;
+  shouldHideCaption?: boolean;
   sizes?: string;
   src: string;
   srcSet?: string;

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -5,19 +5,21 @@ import MediaCaption from './MediaCaption';
 
 type MediaProps = {
   caption?: string;
-  captionDisplay?: string;
+  captionVariant?: 'below' | 'right';
   children: React.ReactElement;
   className?: string;
   credit?: string;
+  hideCaption?: boolean;
   licence?: string;
 };
 
 const Media = ({
   caption,
-  captionDisplay,
+  captionVariant = 'right',
   children,
   className,
   credit,
+  hideCaption,
   licence
 }: MediaProps) => {
   const classNames = cx('cc-media', {
@@ -29,11 +31,12 @@ const Media = ({
       <div className="cc-media__element">{children}</div>
       <MediaCaption
         caption={caption}
-        captionDisplay={captionDisplay}
+        captionVariant={captionVariant}
         className={cx({
-          'cc-media--wide__caption': captionDisplay !== 'below_image'
+          'cc-media--wide__caption': captionVariant === 'right'
         })}
         credit={credit}
+        hideCaption={hideCaption}
         licence={licence}
       />
     </figure>

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -5,6 +5,7 @@ import MediaCaption from './MediaCaption';
 
 type MediaProps = {
   caption?: string;
+  captionDisplay?: string;
   children: React.ReactElement;
   className?: string;
   credit?: string;
@@ -13,6 +14,7 @@ type MediaProps = {
 
 const Media = ({
   caption,
+  captionDisplay,
   children,
   className,
   credit,
@@ -27,7 +29,10 @@ const Media = ({
       <div className="cc-media__element">{children}</div>
       <MediaCaption
         caption={caption}
-        className="cc-media--wide__caption"
+        captionDisplay={captionDisplay}
+        className={cx({
+          'cc-media--wide__caption': captionDisplay !== 'below_image'
+        })}
         credit={credit}
         licence={licence}
       />

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -9,8 +9,8 @@ type MediaProps = {
   children: React.ReactElement;
   className?: string;
   credit?: string;
-  hideCaption?: boolean;
   licence?: string;
+  shouldHideCaption?: boolean;
 };
 
 const Media = ({
@@ -19,8 +19,8 @@ const Media = ({
   children,
   className,
   credit,
-  hideCaption,
-  licence
+  licence,
+  shouldHideCaption
 }: MediaProps) => {
   const classNames = cx('cc-media', {
     [className]: className
@@ -36,8 +36,8 @@ const Media = ({
           'cc-media--wide__caption': captionVariant === 'right'
         })}
         credit={credit}
-        hideCaption={hideCaption}
         licence={licence}
+        shouldHideCaption={shouldHideCaption}
       />
     </figure>
   );

--- a/src/components/Media/MediaCaption.tsx
+++ b/src/components/Media/MediaCaption.tsx
@@ -3,27 +3,29 @@ import cx from 'classnames';
 
 type MediaCaptionProps = {
   caption?: string;
-  captionDisplay?: string;
+  captionVariant?: 'below' | 'right';
   className?: string;
   credit?: string;
+  hideCaption?: boolean;
   licence?: string;
 };
 
 const MediaCaption = ({
   caption,
-  captionDisplay,
+  captionVariant = 'right',
   className,
   credit,
+  hideCaption,
   licence
 }: MediaCaptionProps) => {
   const classNames = cx('cc-media__caption', {
-    'cc-media__caption--below-image': captionDisplay === 'below_image',
+    'cc-media__caption--below-image': captionVariant === 'below',
     [`${className}`]: className
   });
 
-  return (caption && captionDisplay !== 'hide') || credit ? (
+  return (caption && !hideCaption) || credit ? (
     <figcaption className={classNames}>
-      {caption && captionDisplay !== 'hide' && (
+      {caption && !hideCaption && (
         <div
           className="cc-media__caption-detail"
           dangerouslySetInnerHTML={{ __html: caption }}

--- a/src/components/Media/MediaCaption.tsx
+++ b/src/components/Media/MediaCaption.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 
 type MediaCaptionProps = {
   caption?: string;
+  captionDisplay?: string;
   className?: string;
   credit?: string;
   licence?: string;
@@ -10,17 +11,19 @@ type MediaCaptionProps = {
 
 const MediaCaption = ({
   caption,
+  captionDisplay,
   className,
   credit,
   licence
 }: MediaCaptionProps) => {
   const classNames = cx('cc-media__caption', {
+    'cc-media__caption--below-image': captionDisplay === 'below_image',
     [`${className}`]: className
   });
 
-  return caption || credit ? (
+  return (caption && captionDisplay !== 'hide') || credit ? (
     <figcaption className={classNames}>
-      {caption && (
+      {caption && captionDisplay !== 'hide' && (
         <div
           className="cc-media__caption-detail"
           dangerouslySetInnerHTML={{ __html: caption }}

--- a/src/components/Media/MediaCaption.tsx
+++ b/src/components/Media/MediaCaption.tsx
@@ -6,8 +6,8 @@ type MediaCaptionProps = {
   captionVariant?: 'below' | 'right';
   className?: string;
   credit?: string;
-  hideCaption?: boolean;
   licence?: string;
+  shouldHideCaption?: boolean;
 };
 
 const MediaCaption = ({
@@ -15,17 +15,17 @@ const MediaCaption = ({
   captionVariant = 'right',
   className,
   credit,
-  hideCaption,
-  licence
+  licence,
+  shouldHideCaption
 }: MediaCaptionProps) => {
   const classNames = cx('cc-media__caption', {
     'cc-media__caption--below-image': captionVariant === 'below',
     [`${className}`]: className
   });
 
-  return (caption && !hideCaption) || credit ? (
+  return (caption && !shouldHideCaption) || credit ? (
     <figcaption className={classNames}>
-      {caption && !hideCaption && (
+      {caption && !shouldHideCaption && (
         <div
           className="cc-media__caption-detail"
           dangerouslySetInnerHTML={{ __html: caption }}

--- a/src/components/Media/_media.scss
+++ b/src/components/Media/_media.scss
@@ -43,6 +43,18 @@
   }
 }
 
+.cc-media__caption--below-image {
+  @include grid-column(1, 7);
+
+  @include mq(sm) {
+    @include grid-column(2, 12);
+  }
+
+  @include mq(md) {
+    @include grid-column(4, 10);
+  }
+}
+
 .cc-media--wide__caption {
   @include grid-column(1, 7);
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8807

### Context

Currently, when editors add image, caption displays on the right hand side of the image. For some content it does not work. So we need different display option for captions.

In the backend there are 4 different options now:

- **None** -  shows caption on the right 
-  **Right column (default)** - shows caption on the right
- **Below image** - caption below image
- **Hide caption** - hides caption but show meta information (we need this option to prevent creating multiply images with different info)

More info here: https://github.com/wellcometrust/corporate/issues/8768

### This PR

- adds `captionDisplay` option to Media and Image components