### PR TITLE
8815 task: adds iframe resize support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19737,6 +19737,20 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
+    "iframe-resizer": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.2.tgz",
+      "integrity": "sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA=="
+    },
+    "iframe-resizer-react": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iframe-resizer-react/-/iframe-resizer-react-1.1.0.tgz",
+      "integrity": "sha512-FrytSq91AIJaDgE+6uK/Vdd6IR8CrwLoZ6eGmL2qQMPTzF0xlSV2jaSzRRUh5V2fttD7vzl21jvBl97bV40eBw==",
+      "requires": {
+        "iframe-resizer": "^4.3.0",
+        "warning": "^4.0.3"
+      }
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -34280,7 +34294,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.11.0",
     "html-to-text": "^5.1.1",
+    "iframe-resizer-react": "^1.1.0",
     "lodash.throttle": "^4.1.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-hotkeys-hook": "^2.1.3",

--- a/src/components/Iframe/Iframe.tsx
+++ b/src/components/Iframe/Iframe.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 export type IframeProps = {
-  src: string;
-  width: number;
   height: number;
+  src: string;
   title: string;
+  width: number;
 };
 
-export const Iframe = ({ src, width, height, title }: IframeProps) => (
+export const Iframe = ({ height, src, title, width }: IframeProps) => (
   // Make this responsive by ignoring width/height, but using a container div with paddingTop
   // to ensure aspect ratio is respected.
   <div

--- a/src/components/Iframe/Iframe.tsx
+++ b/src/components/Iframe/Iframe.tsx
@@ -1,21 +1,36 @@
 import React from 'react';
+import IframeResizer from 'iframe-resizer-react';
 
 export type IframeProps = {
   height: number;
+  shouldResize?: boolean;
   src: string;
   title: string;
   width: number;
 };
 
-export const Iframe = ({ height, src, title, width }: IframeProps) => (
-  // Make this responsive by ignoring width/height, but using a container div with paddingTop
-  // to ensure aspect ratio is respected.
-  <div
-    className="cc-iframe"
-    style={{ paddingTop: `${((100 * height) / width).toFixed(2)}%` }}
-  >
-    <iframe className="cc-iframe__iframe" src={src} title={title} />
-  </div>
-);
+export const Iframe = ({
+  height,
+  shouldResize,
+  src,
+  title,
+  width
+}: IframeProps) =>
+  shouldResize ? (
+    <IframeResizer
+      src={src}
+      style={{ width: '1px', minWidth: '100%' }}
+      title={title}
+    />
+  ) : (
+    // Make this responsive by ignoring width/height, but using a container div with paddingTop
+    // to ensure aspect ratio is respected.
+    <div
+      className="cc-iframe"
+      style={{ paddingTop: `${((100 * height) / width).toFixed(2)}%` }}
+    >
+      <iframe className="cc-iframe__iframe" src={src} title={title} />
+    </div>
+  );
 
 export default Iframe;


### PR DESCRIPTION
# Context

As part of a content campaign which is being launched on wellcome.org towards the end of August there is a 3rd party agency developing interactive content which will be hosted on wellcome.org in an iframe. The design of this will necessitate a fully responsive iframe, with the height adapting as the content within the iframe changes layout.

# Description

This PR adds the `iframe-resizer-react` https://github.com/davidjbradshaw/iframe-resizer-react to handle this. It adds a prop to the `<Iframe />` component "shouldResize" which conditionally renders the iframe using the `<IframeResizer />` component from the aforementioned library.

# Test (locally)

1. In your local corporate-react, `git checkout task/8815-adds-iframe-resize-support`
1. `npm link` corporate-components in your local corporate-react (https://medium.com/@AidThompsin/how-to-npm-link-to-a-local-version-of-your-dependency-84e82126667a)
2. Set `NEXT_PUBLIC_API_DOMAIN=https://wt-corporated8-develop.codeenigma.net` in local corporate-react .env
3. `npm run dev` (in both corporate-react and corporate-components)
3. Go to http://localhost:3001/what-we-do/our-work/example-iframe