### PR TITLE
8825 bug: fixes incorrect link colour for newsletter intro

### DIFF
--- a/src/components/NewsletterForm/NewsletterFormFooter.tsx
+++ b/src/components/NewsletterForm/NewsletterFormFooter.tsx
@@ -8,14 +8,8 @@ export const NewsletterFormFooter = () => (
     <p>
       We use a third party provider, Dotdigital, to deliver our newsletters. For
       information about how we handle your data, please read our{' '}
-      <a
-        className="newsletter-form__link"
-        href="/about-us/governance/privacy-and-terms"
-      >
-        privacy notice
-      </a>
-      . You can unsubscribe at any time using the links in the email you
-      receive.
+      <a href="/about-us/governance/privacy-and-terms">privacy notice</a>. You
+      can unsubscribe at any time using the links in the email you receive.
     </p>
   </NewsletterFormItem>
 );

--- a/src/components/NewsletterForm/_newsletter-form.scss
+++ b/src/components/NewsletterForm/_newsletter-form.scss
@@ -61,10 +61,6 @@
   flex-basis: 100%;
 }
 
-.newsletter-form__link {
-  @include animated-link($hover-colour: var(--colour-white), $underline-colour: var(--colour-white));
-}
-
 /* Errors */
 
 .newsletter-form__item-error {

--- a/src/components/NewsletterSignup/_newsletter-signup.scss
+++ b/src/components/NewsletterSignup/_newsletter-signup.scss
@@ -21,15 +21,17 @@
   z-index: var(--z-low);
 
   // WYSIWYG content styles
+  .cc-rich-text a,
   a {
+    @include animated-link($hover-colour: var(--colour-white), $underline-colour: var(--colour-white));
     color: var(--colour-white);
+
+    @include hocus {
+      color: var(--colour-white);
+    }
   }
 
-  a:focus,
-  a:hover {
-    color: var(--colour-white);
-  }
-
+  .cc-rich-text a:active,
   a:active {
     color: var(--colour-white);
   }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8825

### Context

The links in the newsletter sign up intro have incorrect colour (black). They should match the colour of the text (white).

<img src="https://user-images.githubusercontent.com/10700103/127462173-35f2c971-064f-4872-984b-1ca692868d58.png" />

### This PR

- adds link colour to `newsletter-signup` class
- remove `newsletter-form__link` class, as link styles are added in one place to the component's root

