### PR TITLE
8846 task: adds person component narrow 1024px style

### DIFF
--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -54,7 +54,12 @@ export const Person = ({
       </figure>
     )}
     <div className="cc-person__wrapper">
-      <div className="cc-person__header">
+      <div
+        className={cx('cc-person__header', {
+          [`cc-person__header--${layoutVariant}`]:
+            layoutVariant && (imageSrc || imageSrcSet)
+        })}
+      >
         <h3 className="cc-person__heading" itemProp="name">
           {name}
         </h3>

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import cx from 'classnames';
 
-import parseHtml from 'utils/parse-html';
 import { ImageElement } from 'Image';
+import Link from 'Link';
+import RichText from 'RichText';
 
 export type PersonProps = {
   description?: string;
@@ -38,7 +39,11 @@ export const Person = ({
     itemType="http://schema.org/Person"
   >
     {(imageSrc || imageSrcSet) && (
-      <figure className="cc-person__image">
+      <figure
+        className={cx('cc-person__image', {
+          [`cc-person__image--${layoutVariant}`]: layoutVariant
+        })}
+      >
         <ImageElement
           itemProp="image"
           sizes={imageSizes}
@@ -73,9 +78,9 @@ export const Person = ({
       {(description || !!links?.length) && (
         <div className="cc-person__body">
           {description && (
-            <div className="cc-person__description">
-              {parseHtml(description)}
-            </div>
+            <RichText className="cc-person__description" itemProp="abstract">
+              {description}
+            </RichText>
           )}
           {!!links?.length && (
             <ul className="cc-person__links">
@@ -84,7 +89,9 @@ export const Person = ({
                   className="cc-person__link-item"
                   key={`${name}-link-${link.url}`}
                 >
-                  <a href={link.url}>{link.title}</a>
+                  <Link className="cc-person__link" to={link.url}>
+                    {link.title}
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -78,7 +78,7 @@ export const Person = ({
       {(description || !!links?.length) && (
         <div className="cc-person__body">
           {description && (
-            <RichText className="cc-person__description" itemProp="abstract">
+            <RichText className="cc-person__description">
               {description}
             </RichText>
           )}

--- a/src/components/Person/_person.scss
+++ b/src/components/Person/_person.scss
@@ -122,24 +122,15 @@
 
 // variant: NARROW
 
-.cc-person--narrow .cc-person__image {
-  @include mq(md) {
+.cc-person__image--narrow {
+  @include mq($from: md, $until: xl) {
     position: absolute;
-  }
-
-  @include mq(xl) {
-    position: static;
   }
 }
 
-.cc-person__image--narrow + .cc-person__wrapper .cc-person__header {
-  @include mq(md) {
+.cc-person__header--narrow {
+  @include mq($from: md, $until: xl) {
     margin-left: calc(var(--person-image-size-responsive) + calc(6 * var(--space-unit)));
     min-height: var(--person-image-size-responsive);
-  }
-
-  @include mq(xl) {
-    margin-left: 0;
-    min-height: 0;
   }
 }

--- a/src/components/Person/_person.scss
+++ b/src/components/Person/_person.scss
@@ -8,7 +8,19 @@
 
 :root {
   --person-image-size-small: calc(10 * var(--space-unit)); // 80px
-  --person-image-size-medium: 162px; // temporary
+  --person-image-size-responsive: var(--person-image-size-small);
+
+  @include mq(sm) {
+    --person-image-size-responsive: calc(12.5 * var(--space-unit)); // 100px
+  }
+
+  @include mq(md) {
+    --person-image-size-responsive: calc(16 * var(--space-unit)); // 128px
+  }
+
+  @include mq(xl) {
+    --person-image-size-responsive: calc(20.25 * var(--space-unit)); // 162px
+  }
 }
 
 .cc-person {
@@ -17,32 +29,22 @@
   @include mq(sm) {
     display: flex;
   }
-
-  a {
-    @include animated-link;
-  }
 }
 
 .cc-person__image {
-  @extend %img-cover;
+  @extend %img-responsive;
 
   background-color: var(--colour-grey-70);
   border-radius: 50%;
   flex-shrink: 0;
-  height: var(--person-image-size-medium);
+  height: var(--person-image-size-responsive);
   margin: 0 0 var(--space-md) 0;
   overflow: hidden;
-  width: var(--person-image-size-medium);
+  width: var(--person-image-size-responsive);
 
   @include mq(sm) {
     margin-bottom: 0;
     margin-right: calc(6 * var(--space-unit));
-  }
-}
-
-.cc-person__image + .cc-person__wrapper {
-  @include mq(sm) {
-    flex-basis: calc(100% - var(--person-image-size-medium));
   }
 }
 
@@ -89,6 +91,10 @@
   }
 }
 
+.cc-person__link {
+  @include animated-link;
+}
+
 // variant: AUTHOR
 
 .cc-person--author {
@@ -96,7 +102,7 @@
   padding: var(--space-lg);
 }
 
-.cc-person--author .cc-person__image {
+.cc-person__image--author {
   height: var(--person-image-size-small);
   width: var(--person-image-size-small);
 
@@ -105,17 +111,35 @@
   }
 }
 
-.cc-person--author .cc-person__image + .cc-person__wrapper {
-  @include mq(sm) {
-    flex-basis: calc(100% - var(--person-image-size-small));
-  }
-}
-
 .cc-person--author .cc-person__heading {
   font-size: var(--heading-xs);
 }
 
 .cc-person--author .cc-person__description,
-.cc-person--author a {
+.cc-person--author .cc-person__link {
   font-size: var(--body-sm);
+}
+
+// variant: NARROW
+
+.cc-person--narrow .cc-person__image {
+  @include mq(md) {
+    position: absolute;
+  }
+
+  @include mq(xl) {
+    position: static;
+  }
+}
+
+.cc-person__image--narrow + .cc-person__wrapper .cc-person__header {
+  @include mq(md) {
+    margin-left: calc(var(--person-image-size-responsive) + calc(6 * var(--space-unit)));
+    min-height: var(--person-image-size-responsive);
+  }
+
+  @include mq(xl) {
+    margin-left: 0;
+    min-height: 0;
+  }
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8846

### Context

The narrow version of Person component has different layout on small desktop.

Small desktop layout:

<img src="https://user-images.githubusercontent.com/10700103/128171298-aa9edb1b-8b4b-4ae7-9eb3-95b7b5494e20.png" />

Large desktop layout:

![Screenshot 2021-08-06 at 16 18 18](https://user-images.githubusercontent.com/10700103/128533248-bcd8369a-19eb-412c-bc73-dea085d4836d.png)

[Link to 6 column person component](https://www.sketch.com/s/8ee1a7e8-969a-4e6c-875f-2e5333a58605/p/F0BAC321-A8D1-4174-BA14-EEC81C62A8ED)

### This PR

- updates styles for `narrow` version
- updates Person component markup (adds RichText and Link components)
- adds option class to the image
- adds image size for different breakpoints 

### Test
1. git fetch task/8846-people-small-desktop-layout
2. npm run storybook
2. `General` > `Layout variant` choose `narrow` option

