### PR TITLE
8843 task: adds compact variant to Person component

### DIFF
--- a/src/components/Person/Person.stories.tsx
+++ b/src/components/Person/Person.stories.tsx
@@ -26,15 +26,15 @@ const PersonExample = () => {
   const organisation = text('Organisation', 'Wellcome Trust', generalGroupID);
   const layoutVariant = select(
     'Layout variant',
-    ['author', 'full-width', 'narrow', 'team'],
-    'full-width',
+    ['author', 'compact', 'narrow', null],
+    null,
     generalGroupID
   );
 
   const links = ['one', 'two', 'three'].map(el => {
     return {
       title: text(`Link ${el} text`, `Link ${el}`, linksGroupID),
-      url: '/'
+      url: `/${el}`
     };
   });
 

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -11,7 +11,7 @@ export type PersonProps = {
   imageSrc?: string;
   imageSrcSet?: string;
   jobTitle?: string;
-  layoutVariant: 'author' | 'full-width' | 'narrow' | 'team';
+  layoutVariant?: 'author' | 'compact' | 'narrow';
   links?: {
     title: string;
     url: string;
@@ -80,9 +80,9 @@ export const Person = ({
           </p>
         )}
       </div>
-      {(description || !!links?.length) && (
+      {((description && layoutVariant !== 'compact') || !!links?.length) && (
         <div className="cc-person__body">
-          {description && (
+          {description && layoutVariant !== 'compact' && (
             <RichText className="cc-person__description">
               {description}
             </RichText>

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -30,81 +30,85 @@ export const Person = ({
   links,
   name,
   organisation
-}: PersonProps) => (
-  <div
-    className={cx('cc-person', {
-      [`cc-person--${layoutVariant}`]: layoutVariant
-    })}
-    itemScope
-    itemType="http://schema.org/Person"
-  >
-    {(imageSrc || imageSrcSet) && (
-      <figure
-        className={cx('cc-person__image', {
-          [`cc-person__image--${layoutVariant}`]: layoutVariant
-        })}
-      >
-        <ImageElement
-          itemProp="image"
-          sizes={imageSizes}
-          src={imageSrc}
-          srcSet={imageSrcSet}
-          alt={`A photograph of the person, ${name}.`}
-        />
-      </figure>
-    )}
-    <div className="cc-person__wrapper">
-      <div
-        className={cx('cc-person__header', {
-          [`cc-person__header--${layoutVariant}`]:
-            layoutVariant && (imageSrc || imageSrcSet)
-        })}
-      >
-        <h3 className="cc-person__heading" itemProp="name">
-          {name}
-        </h3>
-        {jobTitle && (
-          <p
-            className="cc-person__heading cc-person__subheading"
-            itemProp="jobTitle"
-          >
-            {jobTitle}
-          </p>
-        )}
-        {organisation && (
-          <p
-            className="cc-person__heading cc-person__subheading"
-            itemProp="memberOf"
-          >
-            {organisation}
-          </p>
-        )}
-      </div>
-      {((description && layoutVariant !== 'compact') || !!links?.length) && (
-        <div className="cc-person__body">
-          {description && layoutVariant !== 'compact' && (
-            <RichText className="cc-person__description">
-              {description}
-            </RichText>
+}: PersonProps) => {
+  const shouldShowDescription = description && layoutVariant !== 'compact';
+
+  return (
+    <div
+      className={cx('cc-person', {
+        [`cc-person--${layoutVariant}`]: layoutVariant
+      })}
+      itemScope
+      itemType="http://schema.org/Person"
+    >
+      {(imageSrc || imageSrcSet) && (
+        <figure
+          className={cx('cc-person__image', {
+            [`cc-person__image--${layoutVariant}`]: layoutVariant
+          })}
+        >
+          <ImageElement
+            itemProp="image"
+            sizes={imageSizes}
+            src={imageSrc}
+            srcSet={imageSrcSet}
+            alt={`A photograph of the person, ${name}.`}
+          />
+        </figure>
+      )}
+      <div className="cc-person__wrapper">
+        <div
+          className={cx('cc-person__header', {
+            [`cc-person__header--${layoutVariant}`]:
+              layoutVariant && (imageSrc || imageSrcSet)
+          })}
+        >
+          <h3 className="cc-person__heading" itemProp="name">
+            {name}
+          </h3>
+          {jobTitle && (
+            <p
+              className="cc-person__heading cc-person__subheading"
+              itemProp="jobTitle"
+            >
+              {jobTitle}
+            </p>
           )}
-          {!!links?.length && (
-            <ul className="cc-person__links">
-              {links.map(link => (
-                <li
-                  className="cc-person__link-item"
-                  key={`${name}-link-${link.url}`}
-                >
-                  <Link className="cc-person__link" to={link.url}>
-                    {link.title}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+          {organisation && (
+            <p
+              className="cc-person__heading cc-person__subheading"
+              itemProp="memberOf"
+            >
+              {organisation}
+            </p>
           )}
         </div>
-      )}
+        {(shouldShowDescription || !!links?.length) && (
+          <div className="cc-person__body">
+            {shouldShowDescription && (
+              <RichText className="cc-person__description">
+                {description}
+              </RichText>
+            )}
+            {!!links?.length && (
+              <ul className="cc-person__links">
+                {links.map(link => (
+                  <li
+                    className="cc-person__link-item"
+                    key={`${name}-link-${link.url}`}
+                  >
+                    <Link className="cc-person__link" to={link.url}>
+                      {link.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Person;

--- a/src/components/Person/_person.scss
+++ b/src/components/Person/_person.scss
@@ -24,7 +24,7 @@
 }
 
 .cc-person {
-  margin-bottom: var(--space-lg);
+  margin-bottom: var(--space-xl);
 
   @include mq(sm) {
     display: flex;
@@ -133,4 +133,28 @@
     margin-left: calc(var(--person-image-size-responsive) + calc(6 * var(--space-unit)));
     min-height: var(--person-image-size-responsive);
   }
+}
+
+// variant: COMPACT
+.cc-person--compact {
+  display: flex;
+  margin-bottom: calc(4 * var(--space-unit));
+}
+
+.cc-person__image--compact {
+  height: var(--person-image-size-small);
+  margin-right: var(--space-lg);
+  width: var(--person-image-size-small);
+}
+
+.cc-person--compact .cc-person__heading {
+  font-size: var(--heading-sm);
+}
+
+.cc-person--compact .cc-person__link {
+  font-size: var(--body-md);
+}
+
+.cc-person--compact .cc-person__header:after {
+  content: none;
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8843

### Context

Adds styles for the compact variant of People component. This variant is used to create a list of members (e.g. a team members), quote and maybe to replace an Author component at the top of the article.

[link to the Sketch design for Person component](https://www.sketch.com/s/8ee1a7e8-969a-4e6c-875f-2e5333a58605)

Example: 

<img width="303" alt="Screenshot 2021-08-11 at 11 12 24" src="https://user-images.githubusercontent.com/10700103/129011752-aed21d9a-64d6-4a1d-a402-477e6b2bc06f.png">

### This PR

- adds styles for compact variant

### Test
- git fetch task/8843-list-people and git checkout
- `run npm storybook`
- `General` > `Layout variant` choose `compact` option
