### PR TITLE
8431 bug: removes duplicate links on cards

### DIFF
--- a/src/assets/styles/20-tools/_mixins/_pseudo.scss
+++ b/src/assets/styles/20-tools/_mixins/_pseudo.scss
@@ -68,3 +68,27 @@
     @content;
   }
 }
+
+/**
+ * This stretches the link's layout over the whole card, making it clickable like a button.
+ * Important!!
+ * Give the card container element position: relative;
+ *
+ * Usage:
+ *
+ * .selector {
+ *   @include pseudo-image-link;
+ * }
+ *
+ */
+@mixin pseudo-link {
+  &:before {
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 1;
+  }
+}

--- a/src/assets/styles/20-tools/_mixins/_pseudo.scss
+++ b/src/assets/styles/20-tools/_mixins/_pseudo.scss
@@ -77,7 +77,7 @@
  * Usage:
  *
  * .selector {
- *   @include pseudo-image-link;
+ *   @include pseudo-link;
  * }
  *
  */

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -106,16 +106,7 @@
 
 .cc-card__link {
   @include animated-link;
-
-  &:before {
-    bottom: 0;
-    content: '';
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: 1;
-  }
+  @include pseudo-link;
 }
 
 .cc-card__link:before {

--- a/src/components/FeaturedPromo/FeaturedPromo.tsx
+++ b/src/components/FeaturedPromo/FeaturedPromo.tsx
@@ -50,7 +50,7 @@ export const FeaturedPromo = ({
       itemScope
       itemType="https://schema.org/Article"
     >
-      <Link className="cc-featured-promo__figure" to={href}>
+      <div className="cc-featured-promo__figure">
         <figure className="cc-featured-promo__image">
           <ImageElement
             alt={imageAlt}
@@ -62,7 +62,7 @@ export const FeaturedPromo = ({
             width={imageWidth}
           />
         </figure>
-      </Link>
+      </div>
       <div className="cc-featured-promo__body">
         <span className="cc-featured-promo__meta">
           {metaLabel && (

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -7,6 +7,8 @@
 // ----------------------------------
 
 .cc-featured-promo {
+  position: relative;
+
   @include mq(sm) {
     display: flex;
     flex-wrap: nowrap;
@@ -127,3 +129,22 @@
     @include hover-underline;
   }
 }
+
+.cc-featured-promo__link {
+  @include pseudo-link;
+
+  &:before {
+    height: 51vw;
+    width: 100%;
+
+    @include mq(sm) {
+      height: 100%;
+      width: calc((100% / 12) * 5);
+    }
+
+    @include mq(md) {
+      width: 50%;
+    }
+  }
+}
+

--- a/src/components/FeaturedPromo/_featured-promo.scss
+++ b/src/components/FeaturedPromo/_featured-promo.scss
@@ -134,9 +134,6 @@
   @include pseudo-link;
 
   &:before {
-    height: 51vw;
-    width: 100%;
-
     @include mq(sm) {
       height: 100%;
       width: calc((100% / 12) * 5);

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -51,7 +51,7 @@ export const ImageCard = ({
       itemScope
       itemType="https://schema.org/Article"
     >
-      <Link className="cc-image-card__figure" to={href}>
+      <div className="cc-image-card__figure">
         <figure className="cc-image-card__image">
           <ImageElement
             alt={imageAlt}
@@ -63,7 +63,7 @@ export const ImageCard = ({
             width={imageWidth}
           />
         </figure>
-      </Link>
+      </div>
       <div className="cc-image-card__body">
         {(metaLabel || authors?.length) && (
           <span className="cc-image-card__meta">

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -6,7 +6,9 @@
 // 2019-11-11
 // ----------------------------------
 
-// .cc-image-card {}
+.cc-image-card {
+  position: relative;
+}
 
 .cc-image-card__figure {
   display: block;
@@ -113,6 +115,24 @@
   }
 }
 
+.cc-image-card__link {
+  @include pseudo-link;
+
+  &:before {
+    height: 100%;
+    width: 33.33%;
+
+    @include mq(md) {
+      height: 55%;
+      width: 100%;
+    }
+
+    @include mq(lg) {
+      height: 60%;
+    }
+  }
+}
+
 .cc-image-card__date {
   display: block;
   font-size: var(--body-xxs);
@@ -164,5 +184,12 @@
 
   &:last-child {
     margin-bottom: 0;
+  }
+}
+
+.cc-image-card--listing .cc-image-card__link:before {
+  @include mq(md) {
+    height: 100%;
+    width: 33%;
   }
 }

--- a/src/components/ImageCard/_image-card.scss
+++ b/src/components/ImageCard/_image-card.scss
@@ -123,12 +123,12 @@
     width: 33.33%;
 
     @include mq(md) {
-      height: 55%;
+      height: 50%;
       width: 100%;
     }
 
-    @include mq(lg) {
-      height: 60%;
+    @include mq(xl) {
+      height: 62%;
     }
   }
 }
@@ -190,6 +190,6 @@
 .cc-image-card--listing .cc-image-card__link:before {
   @include mq(md) {
     height: 100%;
-    width: 33%;
+    width: 33.33%;
   }
 }

--- a/src/components/ImageCardWithCTA/ImageCardWithCTA.tsx
+++ b/src/components/ImageCardWithCTA/ImageCardWithCTA.tsx
@@ -46,7 +46,7 @@ export const ImageCardWithCTA = ({
       itemScope
       itemType="https://schema.org/Article"
     >
-      <Link className="cc-image-card-with-cta__figure" to={href}>
+      <div className="cc-image-card-with-cta__figure">
         <figure className="cc-image-card-with-cta__image">
           <ImageElement
             alt={imageAlt}
@@ -58,7 +58,7 @@ export const ImageCardWithCTA = ({
             width={imageWidth}
           />
         </figure>
-      </Link>
+      </div>
       <div className="cc-image-card-with-cta__body">
         <TitleElement className="cc-image-card-with-cta__title" itemProp="name">
           <Link className="cc-image-card-with-cta__link" to={href}>

--- a/src/components/ImageCardWithCTA/_image-card-with-cta.scss
+++ b/src/components/ImageCardWithCTA/_image-card-with-cta.scss
@@ -96,12 +96,12 @@
     width: 33%;
 
     @include mq(md) {
-      height: 55%;
+      height: 50%;
       width: 100%;
     }
 
     @include mq(lg) {
-      height: 60%;
+      height: 62%;
     }
   }
 }

--- a/src/components/ImageCardWithCTA/_image-card-with-cta.scss
+++ b/src/components/ImageCardWithCTA/_image-card-with-cta.scss
@@ -5,6 +5,7 @@
 
 .cc-image-card-with-cta {
   margin-bottom: var(--space-lg);
+  position: relative;
 
   @include mq($until: md) {
     display: flex;
@@ -84,6 +85,24 @@
   .cc-image-card-with-cta__figure:hover + .cc-image-card-with-cta__body &,
   .cc-image-card-with-cta__figure:focus + .cc-image-card-with-cta__body & {
     @include hover-underline;
+  }
+}
+
+.cc-image-card-with-cta__link {
+  @include pseudo-link;
+
+  &:before {
+    height: 100%;
+    width: 33%;
+
+    @include mq(md) {
+      height: 55%;
+      width: 100%;
+    }
+
+    @include mq(lg) {
+      height: 60%;
+    }
   }
 }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8431

### Context

An image and a headline text are both links on the cards. If a person clicks on the image or the title text, they are taken to the new page.

This is not ideal for the screen reader users nor users using the keyboard, as they have to tab through two links on every card, doubling the time it takes to get through the page.

### This PR

- removes the link on the image
- adds a specific image aspect ratio to pseudo element to only cover the image and not the whole card
- adds `pseudo-link` mixin

### Test

- pull this branch
- `npm run storybook`
- add `border: 1px solid red;` to `:before` in `pseudo-link` mixin (to see what part of image is covered by pseudo link)

