### PR TITLE
8958 task: updates error message markup

### DIFF
--- a/src/components/FormFieldError/FormFieldError.tsx
+++ b/src/components/FormFieldError/FormFieldError.tsx
@@ -27,22 +27,22 @@ export const FormFieldError = ({
   });
 
   return (
-    <span className={classNames} id={id}>
+    <div className={classNames}>
       <Icon className="cc-form-field-error__icon" name="exclamationMark" />
       {typeof errors === 'string' && (
-        <p className="cc-form-field-error__text">
+        <span className="cc-form-field-error__text" id={id}>
           <VisuallyHidden>Error: </VisuallyHidden>
           {errors}
-        </p>
+        </span>
       )}
       {typeof errors === 'object' && Object.entries(errors).length === 1 && (
-        <p className="cc-form-field-error__text">
+        <span className="cc-form-field-error__text" id={id}>
           <VisuallyHidden>Error: </VisuallyHidden>
           {Object.values(errors)[0]}
-        </p>
+        </span>
       )}
       {typeof errors === 'object' && Object.entries(errors).length > 1 && (
-        <ul className="cc-form-field-error__list">
+        <ul className="cc-form-field-error__list" id={id}>
           {Object.entries(errors).map(([type, message]) => (
             <li
               key={`${id}-error-text-${type}`}
@@ -54,7 +54,7 @@ export const FormFieldError = ({
           ))}
         </ul>
       )}
-    </span>
+    </div>
   );
 };
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8958

### Context

Some error messages were not conveyed to screen reader users. Grant reference number, Amount and currency, dates for leave.
A pattern was identified whereby the inputs present with hint text and an error message are not relaying the error message back to the user. This is because the ID used is not directly on the span that contains the error message. Similar issue on contact form.

### This PR

- updates error message markup
