### PR TITLE
8957 task: removes newsletter pop-up error

### DIFF
--- a/src/components/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/NewsletterForm/NewsletterForm.tsx
@@ -115,7 +115,9 @@ export const NewsletterForm = ({
    * @param {Object} HTMLInputElement - value key of an HTMLInputElement
    */
   const handleEmailBlur = ({ value }: HTMLInputElement) => {
-    setEmailError(!isEmail(value));
+    if (value) {
+      setEmailError(!isEmail(value));
+    }
   };
 
   /**

--- a/src/components/NewsletterForm/NewsletterFormEmail.tsx
+++ b/src/components/NewsletterForm/NewsletterFormEmail.tsx
@@ -32,7 +32,7 @@ export const NewsletterFormEmail = ({
         Your email address
       </label>
       <input
-        aria-describedby={hasError && `${id}-error`}
+        aria-describedby={hasError ? `${id}-error` : null}
         autoComplete="email"
         className={classNames}
         id={id}

--- a/src/components/NewsletterForm/NewsletterFormEmail.tsx
+++ b/src/components/NewsletterForm/NewsletterFormEmail.tsx
@@ -45,14 +45,14 @@ export const NewsletterFormEmail = ({
         value={value}
       />
       {hasError && (
-        <span className="newsletter-form__item-error" id={`${id}-error`}>
-          <VisuallyHidden>
-            Error on the &quot;Your email address&quot; field.
-          </VisuallyHidden>
-          <span className="newsletter-form__item-error-text">
+        <div className="newsletter-form__item-error">
+          <span className="newsletter-form__item-error-text" id={`${id}-error`}>
+            <VisuallyHidden>
+              Error on the &quot;Your email address&quot; field.
+            </VisuallyHidden>
             Please provide a valid email address.
           </span>
-        </span>
+        </div>
       )}
     </NewsletterFormItem>
   );

--- a/src/components/NewsletterForm/NewsletterFormEmail.tsx
+++ b/src/components/NewsletterForm/NewsletterFormEmail.tsx
@@ -32,6 +32,7 @@ export const NewsletterFormEmail = ({
         Your email address
       </label>
       <input
+        aria-describedby={hasError && `${id}-error`}
         autoComplete="email"
         className={classNames}
         id={id}
@@ -44,14 +45,14 @@ export const NewsletterFormEmail = ({
         value={value}
       />
       {hasError && (
-        <div className="newsletter-form__item-error">
+        <span className="newsletter-form__item-error" id={`${id}-error`}>
           <VisuallyHidden>
             Error on the &quot;Your email address&quot; field.
           </VisuallyHidden>
           <span className="newsletter-form__item-error-text">
             Please provide a valid email address.
           </span>
-        </div>
+        </span>
       )}
     </NewsletterFormItem>
   );

--- a/src/components/NewsletterForm/NewsletterFormError.tsx
+++ b/src/components/NewsletterForm/NewsletterFormError.tsx
@@ -4,7 +4,10 @@ import NewsletterFormItem from './NewsletterFormItem';
 
 export const NewsletterFormError = () => (
   <NewsletterFormItem type="error">
-    <div className="newsletter-form__response-msg newsletter-form__response-msg--error">
+    <div
+      className="newsletter-form__response-msg newsletter-form__response-msg--error"
+      role="status"
+    >
       <p className="newsletter-form__response-msg-text">
         There was a problem with your submission, please try again.
       </p>

--- a/src/components/NewsletterForm/_newsletter-form.scss
+++ b/src/components/NewsletterForm/_newsletter-form.scss
@@ -68,7 +68,6 @@
   background-image: none;
   border-radius: calc(0.25 * var(--space-unit));
   color: var(--X-colour-error-red);
-  display: inline-block;
   font-size: var(--body-sm);
   margin-top: var(--space-md);
   padding-bottom: var(--space-xs);

--- a/src/components/NewsletterForm/_newsletter-form.scss
+++ b/src/components/NewsletterForm/_newsletter-form.scss
@@ -68,6 +68,7 @@
   background-image: none;
   border-radius: calc(0.25 * var(--space-unit));
   color: var(--X-colour-error-red);
+  display: inline-block;
   font-size: var(--body-sm);
   margin-top: var(--space-md);
   padding-bottom: var(--space-xs);
@@ -83,8 +84,8 @@
     border-top: 0;
     content: '';
     left: 1rem;
-    margin-left: -var(--space-unit);
-    margin-top: -var(--space-unit);
+    margin-left: calc(-1 * var(--space-unit));
+    margin-top: calc(-1 * var(--space-unit));
     position: absolute;
     top: 0.125rem;
   }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8957

### Context

When tabbing past the ‘Your email address’ input field error handling is triggered and an error occurs; however, this is not conveyed to screen reader users at this point. Remove the pop-up error altogether and only trigger error handling once the users makes an incorrect submission by inputting the incorrect email address format.

### This PR

- shows error message only after the incorrect email address format is used
- adds `aria-describedby` and id to convey error message to screen reader user