### PR TITLE
8971 task: adds focus indicator to radio button

### DIFF
--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -61,7 +61,7 @@
    */
   // Focused radio
   .cc-radio-input__input-element:not(:disabled):focus ~ &:before {
-    box-shadow: 0 0 0 2px var(--colour-blue-30);
+    box-shadow: 0 0 0 3px var(--colour-blue-30);
   }
 
   /**
@@ -73,7 +73,7 @@
   }
 
   .cc-radio-input__input-element:not(:disabled):focus-visible ~ &:before {
-    box-shadow: 0 0 0 2px var(--colour-blue-30);
+    box-shadow: 0 0 0 3px var(--colour-blue-30);
   }
 
   // Disabled

--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -56,6 +56,26 @@
     border-color: var(--colour-blue-60);
   }
 
+  /**
+   * @see focus-visible: https://css-tricks.com/focus-visible-and-backwards-compatibility/
+   */
+  // Focused radio
+  .cc-radio-input__input-element:not(:disabled):focus ~ &:before {
+    box-shadow: 0 0 0 2px var(--colour-blue-30);
+  }
+
+  /**
+   * Browsers will ignore the entire block when using a pseudo-class they don’t understand/support
+   */
+  .cc-radio-input__input-element:not(:disabled):focus:not(:focus-visible) ~ &:before {
+    // undo all the above focused styles
+    box-shadow: none;
+  }
+
+  .cc-radio-input__input-element:not(:disabled):focus-visible ~ &:before {
+    box-shadow: 0 0 0 2px var(--colour-blue-30);
+  }
+
   // Disabled
   .cc-radio-input__input-element:disabled ~ &:before {
     background-color: var(--colour-grey-05);


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8971

### Context

No highlight mechanism surrounding radio button once selected. If a radio button is selected and the user needs to tab back to the buttons to make a different selection, there is no visible focus indicator present. Ensure there is a visible focus indicator surrounding the radio button once a selection has been made to enable keyboard only users to clearly see when focus is placed on the selected radio button.

### This PR

- adds focus to radio button

<img width="516" alt="Screenshot 2021-09-15 at 17 31 54" src="https://user-images.githubusercontent.com/10700103/133473849-88c730b0-e719-4b60-877a-f4ea4e6970de.png">

