### PR TITLE
8961 task: un-fixes fixed cookie message when the browser is zoomed

### DIFF
--- a/src/components/CookieMessage/_cookie-message.scss
+++ b/src/components/CookieMessage/_cookie-message.scss
@@ -10,7 +10,9 @@
 
   /**
     * When the browser zoom is used to scale content to 400%,
-    * we should un-fixed Cookie message as the height of the viewport is limited.
+    * we should un-fix Cookie banner as the height of the viewport is limited.
+    *
+    * Present content with fixed Cookie only when there is enough space.
     *
     * @see {@link https://www.w3.org/WAI/WCAG21/Techniques/css/C34.html}
    */

--- a/src/components/CookieMessage/_cookie-message.scss
+++ b/src/components/CookieMessage/_cookie-message.scss
@@ -5,9 +5,18 @@
   left: 0;
   letter-spacing: var(--body-letter-spacing);
   padding: calc(2 * var(--space-unit));
-  position: fixed;
   width: 100%;
   z-index: 105;
+
+  /**
+    * When the browser zoom is used to scale content to 400%,
+    * we should un-fixed Cookie message as the height of the viewport is limited.
+    *
+    * @see {@link https://www.w3.org/WAI/WCAG21/Techniques/css/C34.html}
+   */
+  @media (min-height: 480px) {
+    position: fixed;
+  }
 
   @include mq(sm) {
     padding: calc(4 * var(--space-unit)) calc(6 * var(--space-unit));


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8961

### Context

Accessibility report:
> Obscures much of the content when zoomed to 400%, if cookie banner present, no scrollable content is visible and cookie preference options omitted.

One of the technique to implement reflow is to un-fix sticky components. Please see [Using media queries to un-fixing sticky headers / footers](https://www.w3.org/WAI/WCAG21/Techniques/css/C34.html)

### This PR

- uses `@media (min-height: 480px)` to add fixed components when there is enough space.