### PR TITLE
8961 task(refactor): add min-height variable

### DIFF
--- a/src/assets/styles/10-settings/_mq.scss
+++ b/src/assets/styles/10-settings/_mq.scss
@@ -15,4 +15,12 @@ $mq-breakpoints: (
   xxl: 1500px
 ) !default;
 
+/**
+ * @media (min-height: 30em) is used to add fixed components when there is enough space in the browser's viewport.
+ * Prevents from obstructing the content when the browser is zoomed and the height of the viewport is limited .
+ *
+ * @see {@link https://www.w3.org/WAI/WCAG21/Techniques/css/C34.html}
+*/
+$min-height: 'min-height: 30em';
+
 @import '~sass-mq';

--- a/src/components/CookieMessage/_cookie-message.scss
+++ b/src/components/CookieMessage/_cookie-message.scss
@@ -16,7 +16,7 @@
     *
     * @see {@link https://www.w3.org/WAI/WCAG21/Techniques/css/C34.html}
    */
-  @media (min-height: 480px) {
+  @media ($min-height) {
     position: fixed;
   }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8961

### Context

Accessibility report:
> Obscures much of the content when zoomed to 400%, if cookie banner present, no scrollable content is visible and cookie preference options omitted.

One of the technique to implement reflow is to un-fix sticky components. Please see [Using media queries to un-fixing sticky headers / footers](https://www.w3.org/WAI/WCAG21/Techniques/css/C34.html)

### This PR

- refactor min-height media query to match changes in the [CR](https://github.com/wellcometrust/corporate-react/pull/1101)