### PR TITLE
8664 task: adds Author to Quote component

### DIFF
--- a/src/components/Author/Author.stories.tsx
+++ b/src/components/Author/Author.stories.tsx
@@ -2,20 +2,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select, text } from '@storybook/addon-knobs';
 
-import Quote from './Quote';
-import Readme from './Quote.md';
+import Author from './Author';
 
-const QuoteExample = () => {
+const AuthorExample = () => {
   const generalGroupID = 'General';
   const linksGroupID = 'Links';
   const imageGroupID = 'Image';
-
-  const cite = text('Cite', 'Citation or quote source', generalGroupID);
-  const quoteBody = text(
-    'Text',
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras eget fringilla massa. Quisque ut enim vehicula, volutpat dui et, gravida purus. In eget blandit libero.',
-    generalGroupID
-  );
 
   const imageSrc = text(
     'Image path',
@@ -34,19 +26,25 @@ const QuoteExample = () => {
     };
   });
 
-  const author = {
-    imageSrc: hasImage && imageSrc,
-    jobTitle,
-    links,
-    name,
-    organisation
-  };
+  const layoutVariant = select(
+    'Layout variant',
+    ['horizontal', null],
+    null,
+    generalGroupID
+  );
 
-  return <Quote cite={cite} text={quoteBody} author={author} />;
+  return (
+    <Author
+      imageSrc={hasImage && imageSrc}
+      layoutVariant={layoutVariant}
+      jobTitle={jobTitle}
+      links={links}
+      name={name}
+      organisation={organisation}
+    />
+  );
 };
 
-const stories = storiesOf('Components/Quote', module);
+const stories = storiesOf('Components/Author', module);
 
-stories.add('Quote', QuoteExample, {
-  readme: { sidebar: Readme }
-});
+stories.add('Author', AuthorExample);

--- a/src/components/Author/Author.tsx
+++ b/src/components/Author/Author.tsx
@@ -17,6 +17,7 @@ export type AuthorProps = {
   }[];
   name: string;
   organisation?: string;
+  titleAs?: 'h2' | 'p';
 };
 
 export const Author = ({
@@ -28,8 +29,10 @@ export const Author = ({
   jobTitle,
   links,
   name,
-  organisation
+  organisation,
+  titleAs = 'h2'
 }: AuthorProps) => {
+  const TitleElement = titleAs;
   const classNames = cx('cc-author', {
     [`cc-author--${layoutVariant}`]: layoutVariant,
     [className]: className
@@ -49,9 +52,9 @@ export const Author = ({
         </figure>
       )}
       <div className="cc-author__body">
-        <h2 className="cc-author__name" itemProp="name">
+        <TitleElement className="cc-author__name" itemProp="name">
           {name}
-        </h2>
+        </TitleElement>
         {jobTitle && (
           <p className="cc-author__byline" itemProp="jobTitle">
             {jobTitle}

--- a/src/components/Author/Author.tsx
+++ b/src/components/Author/Author.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import cx from 'classnames';
 
 import { ImageElement } from 'Image';
 import Link from 'Link';
 
 export type AuthorProps = {
+  className?: string;
   imageSizes?: string;
   imageSrc?: string;
   imageSrcSet?: string;
+  layoutVariant?: 'horizontal';
   jobTitle?: string;
   links?: {
     title: string;
@@ -17,56 +20,65 @@ export type AuthorProps = {
 };
 
 export const Author = ({
+  className,
   imageSizes,
   imageSrc,
   imageSrcSet,
+  layoutVariant,
   jobTitle,
   links,
   name,
   organisation
-}: AuthorProps) => (
-  <div className="cc-author" itemScope itemType="http://schema.org/Person">
-    {(imageSrc || imageSrcSet) && (
-      <figure className="cc-author__image">
-        <ImageElement
-          itemProp="image"
-          sizes={imageSizes}
-          src={imageSrc}
-          srcSet={imageSrcSet}
-          alt={`A photograph of the author, ${name}.`}
-        />
-      </figure>
-    )}
-    <div className="cc-author__body">
-      <h2 className="cc-author__name" itemProp="name">
-        {name}
-      </h2>
-      {jobTitle && (
-        <p className="cc-author__byline" itemProp="jobTitle">
-          {jobTitle}
-        </p>
+}: AuthorProps) => {
+  const classNames = cx('cc-author', {
+    [`cc-author--${layoutVariant}`]: layoutVariant,
+    [className]: className
+  });
+
+  return (
+    <div className={classNames} itemScope itemType="http://schema.org/Person">
+      {(imageSrc || imageSrcSet) && (
+        <figure className="cc-author__image">
+          <ImageElement
+            itemProp="image"
+            sizes={imageSizes}
+            src={imageSrc}
+            srcSet={imageSrcSet}
+            alt={`A photograph of the author, ${name}.`}
+          />
+        </figure>
       )}
-      {organisation && (
-        <p className="cc-author__byline" itemProp="memberOf">
-          {organisation}
-        </p>
-      )}
-      {!!links?.length && (
-        <ul className="cc-author__links">
-          {links.map(link => (
-            <li
-              className="cc-author__link-item"
-              key={`${name}-link-${link.url}`}
-            >
-              <Link className="cc-author__link" to={link.url}>
-                {link.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
+      <div className="cc-author__body">
+        <h2 className="cc-author__name" itemProp="name">
+          {name}
+        </h2>
+        {jobTitle && (
+          <p className="cc-author__byline" itemProp="jobTitle">
+            {jobTitle}
+          </p>
+        )}
+        {organisation && (
+          <p className="cc-author__byline" itemProp="memberOf">
+            {organisation}
+          </p>
+        )}
+        {!!links?.length && (
+          <ul className="cc-author__links">
+            {links.map(link => (
+              <li
+                className="cc-author__link-item"
+                key={`${name}-link-${link.url}`}
+              >
+                <Link className="cc-author__link" to={link.url}>
+                  {link.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Author;

--- a/src/components/Author/_author.scss
+++ b/src/components/Author/_author.scss
@@ -22,6 +22,7 @@
   border-radius: 50%;
   flex-shrink: 0;
   height: var(--image-size);
+  margin-left: 0;
   margin-right: var(--space-lg);
   overflow: hidden;
   width: var(--image-size);
@@ -60,4 +61,14 @@
 
 .cc-author__link {
   @include animated-link;
+}
+
+// variant: horizontal
+
+.cc-author--horizontal {
+  display: flex;
+
+  .cc-author__image {
+    margin: 0 var(--space-lg) 0 0;
+  }
 }

--- a/src/components/Quote/Quote.stories.tsx
+++ b/src/components/Quote/Quote.stories.tsx
@@ -17,6 +17,8 @@ const QuoteExample = () => {
     generalGroupID
   );
 
+  const hasAuthor = boolean('Has author?', true, generalGroupID);
+
   const imageSrc = text(
     'Image path',
     `https://via.placeholder.com/300`,
@@ -34,7 +36,7 @@ const QuoteExample = () => {
     };
   });
 
-  const author = {
+  const author = hasAuthor && {
     imageSrc: hasImage && imageSrc,
     jobTitle,
     links,

--- a/src/components/Quote/Quote.tsx
+++ b/src/components/Quote/Quote.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import cx from 'classnames';
 
+import Author, { AuthorProps } from 'Author/Author';
 import RichText from 'RichText';
 
 type QuoteProps = {
+  author?: AuthorProps;
   className?: string;
   cite?: string;
   text: string;
 };
 
-export const Quote = ({ className, cite, text }: QuoteProps) => {
+export const Quote = ({ author, className, cite, text }: QuoteProps) => {
   const classNames = cx('cc-quote', {
-    [`${className}`]: className
+    [className]: className
   });
 
   return (
@@ -19,7 +21,19 @@ export const Quote = ({ className, cite, text }: QuoteProps) => {
       <div className="cc-quote__body">
         <RichText>{text}</RichText>
       </div>
-      {cite && <cite className="cc-quote__cite">{cite}</cite>}
+      {author && (
+        <Author
+          className="cc-quote__author"
+          imageSrc={author.imageSrc}
+          imageSrcSet={author.imageSrcSet}
+          layoutVariant="horizontal"
+          jobTitle={author.jobTitle}
+          links={author.links}
+          name={author.name}
+          organisation={author.organisation}
+        />
+      )}
+      {cite && !author && <cite className="cc-quote__cite">{cite}</cite>}
     </blockquote>
   );
 };

--- a/src/components/Quote/Quote.tsx
+++ b/src/components/Quote/Quote.tsx
@@ -18,7 +18,11 @@ export const Quote = ({ author, className, cite, text }: QuoteProps) => {
 
   return (
     <blockquote className={classNames}>
-      <div className="cc-quote__body">
+      <div
+        className={cx('cc-quote__body', {
+          'cc-quote__body--short-quote': text.trim().length <= 200
+        })}
+      >
         <RichText>{text}</RichText>
       </div>
       {author && (
@@ -31,6 +35,7 @@ export const Quote = ({ author, className, cite, text }: QuoteProps) => {
           links={author.links}
           name={author.name}
           organisation={author.organisation}
+          titleAs="p"
         />
       )}
       {cite && !author && <cite className="cc-quote__cite">{cite}</cite>}

--- a/src/components/Quote/_quote.scss
+++ b/src/components/Quote/_quote.scss
@@ -26,6 +26,10 @@
   }
 }
 
+.cc-quote__body--short-quote {
+  font-size: var(--body-lg);
+}
+
 .cc-quote__author {
   * {
     font-size: var(--body-sm);
@@ -36,7 +40,4 @@
   color: var(--meta-text-colour);
   display: block;
   font-style: normal;
-  margin-top: calc(-4 * var(--space-unit));
-  padding-right: calc(6 * var(--space-unit));
-  position: relative;
 }

--- a/src/components/Quote/_quote.scss
+++ b/src/components/Quote/_quote.scss
@@ -6,59 +6,29 @@
 // 2019-11-11
 // ----------------------------------
 
-%quote-mark {
-  background-image: url('data:image/svg+xml,%3Csvg%20viewBox%3D%220%200%2033%2032%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M14.48%200v5.554c-4.395.544-7.796%204.263-7.796%208.77%200%20.762.097%201.503.28%202.209h7.517V32H0V16.533h.04c-.027-.365-.04-.734-.04-1.105C0%207.258%206.388.567%2014.48%200zM33%200v5.554c-4.396.544-7.797%204.263-7.797%208.77%200%20.762.097%201.503.28%202.209H33V32H18.52V16.533h.038c-.026-.365-.039-.734-.039-1.105C18.52%207.258%2024.907.567%2033%200z%22%20fill%3D%22%23E6E6E6%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E');
-  background-repeat: no-repeat;
-}
-
 .cc-quote {
+  border-left: 3px solid var(--colour-amber-30);
   line-height: var(--body-line-height);
-  margin: 0;
+  margin: 0 0 0 var(--space-lg);
+  padding-left: var(--space-lg);
 }
 
 .cc-quote__body {
-  font-family: var(--font-secondary);
-
-  // padding bottom applied to enable consistent overall height of blockquote
-  // and positioning of close quote mark with or without citation
-  padding-bottom: calc(6 * var(--space-unit));
-  position: relative;
-
-  &:before,
-  &:after {
-    @extend %quote-mark;
-    background-size: 100% auto;
-    color: var(--colour-grey-10);
-    content: '';
-    display: block;
-    font-family: var(--font-primary);
-    font-size: 100px;
-    font-weight: bold;
-    height: 32px;
-    width: 33px;
-  }
-
-  &:before {
-    margin-bottom: var(--space-unit);
-  }
-
-  &:after {
-    bottom: 0;
-    position: absolute;
-    right: 0;
-    transform: rotate(180deg);
-  }
+  font-style: italic;
+  margin-bottom: calc(4 * var(--space-unit));
 
   p {
     @extend %body-regular;
   }
 
-  a {
-    @extend %anchor-base;
-  }
-
   > :last-child {
     margin-bottom: 0;
+  }
+}
+
+.cc-quote__author {
+  * {
+    font-size: var(--body-sm);
   }
 }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8664

### This PR

- adds Author to Quote component
- adds Author story
- updates Quote story
- adds `horizontal` variant to Author
- updates Quote styles to match [new design](https://www.sketch.com/s/8ee1a7e8-969a-4e6c-875f-2e5333a58605/a/9PxMdlp)

### Test

- `npm run storybook`
- see `Quote` component

<img width="676" alt="Screenshot 2021-10-04 at 14 50 52" src="https://user-images.githubusercontent.com/10700103/135863363-2daf2af1-12d7-4ade-ab6e-dd17c79d0792.png">

### Notes

- We have different font size for shorter and longer quotes: 20px when quote is under 200 characters and 16px when quote is over 200 characters.
- I kept `<cite>` as the changes are not implemented in the backend, and it is hidden if `<author>` is available.