### PR TITLE
9041 task(style): radio buttons/checkboxes are not discoverable for Dragon users

### DIFF
--- a/src/assets/styles/10-settings/_sizes.scss
+++ b/src/assets/styles/10-settings/_sizes.scss
@@ -16,6 +16,4 @@
   --secondary-nav-height: calc(2 * var(--space-unit));
 
   --search-height-md: calc(8 * var(--space-unit));
-
-  --checkbox-radio-size: calc(2 * var(--space-unit));
 }

--- a/src/assets/styles/10-settings/_sizes.scss
+++ b/src/assets/styles/10-settings/_sizes.scss
@@ -16,4 +16,6 @@
   --secondary-nav-height: calc(2 * var(--space-unit));
 
   --search-height-md: calc(8 * var(--space-unit));
+
+  --checkbox-radio-size: calc(2 * var(--space-unit));
 }

--- a/src/assets/styles/20-tools/_mixins/_a11y.scss
+++ b/src/assets/styles/20-tools/_mixins/_a11y.scss
@@ -27,3 +27,27 @@
   position: absolute;
   width: 1px;
 }
+
+/**
+ * Hide radio buttons and checkboxes visually (for screen-readers).
+ * Allows Dragon users to access the inputs by using standard voice commands,
+ * such as “Click button”.
+ *
+ * Usage:
+ *
+ * .selector {
+ *   @include visually-hidden-input($top: 0.25rem);
+ * }
+ *
+ */
+
+@mixin visually-hidden-input($top: 0) {
+  cursor: pointer;
+  height: var(--checkbox-radio-size);
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  top: $top;
+  width: var(--checkbox-radio-size);
+  z-index: 1;
+}

--- a/src/assets/styles/20-tools/_mixins/_a11y.scss
+++ b/src/assets/styles/20-tools/_mixins/_a11y.scss
@@ -29,9 +29,14 @@
 }
 
 /**
- * Hide radio buttons and checkboxes visually (for screen-readers).
- * Allows Dragon users to access the inputs by using standard voice commands,
- * such as “Click button”.
+ * Hide checkboxes, radio buttons and any other interactive form elements
+ * that we may want to restyle, including file inputs.
+ *
+ * These elements must be discoverable by all screen reader users, particularly those navigating by touch,
+ * and Dragon users using standard voice commands, such as “Click button”.
+ * Dragon is a speech recognition software.
+ *
+ * @see {@link https://www.sarasoueidan.com/blog/inclusively-hiding-and-styling-checkboxes-and-radio-buttons/}
  *
  * Usage:
  *
@@ -41,13 +46,13 @@
  *
  */
 
-@mixin visually-hidden-input($top: 0) {
+@mixin visually-hidden-input($top: 0, $size: var(--checkbox-radio-size)) {
   cursor: pointer;
-  height: var(--checkbox-radio-size);
+  height: $size;
   margin: 0;
   opacity: 0;
   position: absolute;
   top: $top;
-  width: var(--checkbox-radio-size);
+  width: $size;
   z-index: 1;
 }

--- a/src/components/Checkbox/_checkbox.scss
+++ b/src/components/Checkbox/_checkbox.scss
@@ -6,6 +6,10 @@
 // 2019-11-11
 // ----------------------------------
 
+:root {
+  --checkbox-radio-size: calc(2 * var(--space-unit));
+}
+
 // Hide the <input /> element
 .cc-checkbox__input {
   @include visually-hidden-input($top: 0.37rem);

--- a/src/components/Checkbox/_checkbox.scss
+++ b/src/components/Checkbox/_checkbox.scss
@@ -8,7 +8,7 @@
 
 // Hide the <input /> element
 .cc-checkbox__input {
-  @extend %visually-hidden;
+  @include visually-hidden-input($top: 0.37rem);
 }
 
 .cc-checkbox {
@@ -16,12 +16,11 @@
 }
 
 .cc-checkbox__label {
-  --checkbox-width: calc(2 * var(--space-unit));
   --checkbox-inner-width: calc(0.75 * var(--space-unit));
 
   cursor: pointer;
   display: inline-block;
-  padding-left: calc(var(--checkbox-width) + var(--space-md));
+  padding-left: calc(var(--checkbox-radio-size) + var(--space-md));
   position: relative;
 
   &:before {
@@ -29,17 +28,17 @@
     border: 1px solid var(--colour-grey-20);
     border-radius: 2px;
     content: '';
-    height: var(--checkbox-width);
+    height: var(--checkbox-radio-size);
     left: 0;
     position: absolute;
     top: 0.37rem;
-    width: var(--checkbox-width);
+    width: var(--checkbox-radio-size);
   }
 
   &:after {
     box-shadow: inset 0 0 0 0;
     height: var(--checkbox-inner-width);
-    left: calc((var(--checkbox-width) - var(--checkbox-inner-width)) / 2);
+    left: calc((var(--checkbox-radio-size) - var(--checkbox-inner-width)) / 2);
     opacity: 0;
     transition: opacity 0.2s, transform 0.2s;
     width: var(--checkbox-inner-width);

--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -8,7 +8,7 @@
 
 // Hide the <input /> element
 .cc-radio-input__input-element {
-  @include visually-hidden-input($top: 0.25rem);
+  @include visually-hidden-input($top: 0.3125rem);
 }
 
 .cc-radio-input {

--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -6,12 +6,20 @@
 // 2019-11-11
 // ----------------------------------
 
+// Hide the <input /> element
+.cc-radio-input__input-element {
+  @include visually-hidden-input($top: 0.25rem);
+}
+
+.cc-radio-input {
+  position: relative;
+}
+
 .cc-radio-input__label {
-  --radio-width: calc(2 * var(--space-unit));
   --radio-inner-width: calc(0.75 * var(--space-unit));
 
   cursor: pointer;
-  padding-left: calc(var(--radio-width) + var(--space-md));
+  padding-left: calc(var(--checkbox-radio-size) + var(--space-md));
   position: relative;
 
   &:after,
@@ -22,15 +30,15 @@
     border: 1px solid var(--colour-grey-20);
     border-radius: 50%;
     content: '';
-    height: var(--radio-width);
+    height: var(--checkbox-radio-size);
     left: 0;
-    width: var(--radio-width);
+    width: var(--checkbox-radio-size);
   }
 
   &:after {
     box-shadow: inset 0 0 0 0;
     height: var(--radio-inner-width);
-    left: calc((var(--radio-width) - var(--radio-inner-width)) / 2);
+    left: calc((var(--checkbox-radio-size) - var(--radio-inner-width)) / 2);
     opacity: 0;
     transition: opacity 0.2s, transform 0.2s;
     width: var(--radio-inner-width);
@@ -85,9 +93,4 @@
   .cc-radio-input__input-element:disabled ~ & {
     color: var(--colour-grey-30);
   }
-}
-
-// Hide the <input /> element
-.cc-radio-input__input-element {
-  @extend %visually-hidden;
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9041

### Context

Accessibility audit:

The customised radio buttons and checkboxes are not discoverable for Dragon users using standard voice command; such as “Click button”.

This issue occurs when the original elements are not hidden correctly with the correct CSS.

[gov.uk radio button example](https://design-system.service.gov.uk/components/radios/default/index.html) -> inspect to see the CSS

### This PR

- hides the checkbox and radio buttons using updated CSS
- created reusable CSS variable for the checkbox and radio buttons size

