### PR TITLE
9052 task: inverted colour radio buttons

### DIFF
--- a/src/assets/styles/20-tools/_mixins/_a11y.scss
+++ b/src/assets/styles/20-tools/_mixins/_a11y.scss
@@ -55,4 +55,8 @@
   top: $top;
   width: $size;
   z-index: 1;
+
+  &:disabled {
+    cursor: default;
+  }
 }

--- a/src/assets/styles/20-tools/_mixins/_a11y.scss
+++ b/src/assets/styles/20-tools/_mixins/_a11y.scss
@@ -45,8 +45,7 @@
  * }
  *
  */
-// $size: 1.125rem, which is 18px (2px bigger than checkbox/radio sizes)
-@mixin visually-hidden-input($top: 0.25rem, $size: 1.125rem) {
+@mixin visually-hidden-input($top: var(--space-xs), $size: calc(2 * var(--space-unit))) {
   cursor: pointer;
   height: $size;
   margin: 0;

--- a/src/assets/styles/20-tools/_mixins/_a11y.scss
+++ b/src/assets/styles/20-tools/_mixins/_a11y.scss
@@ -45,8 +45,8 @@
  * }
  *
  */
-
-@mixin visually-hidden-input($top: 0, $size: var(--checkbox-radio-size)) {
+// $size: 1.125rem, which is 18px (2px bigger than checkbox/radio sizes)
+@mixin visually-hidden-input($top: 0.25rem, $size: 1.125rem) {
   cursor: pointer;
   height: $size;
   margin: 0;

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -11,6 +11,9 @@ const CheckboxExample = () => {
   const generalGroupID = 'General';
   const labelsGroupId = 'Labels';
 
+  const hasError = boolean('Has error?', false, generalGroupID);
+  const isDisabled = boolean('Is disabled?', false, generalGroupID);
+
   const errorMessage = text(
     'Error message',
     'Please confirm that your current organisation has been notified.',
@@ -26,8 +29,7 @@ const CheckboxExample = () => {
     'I confirm that I have discussed this transfer with the research office at my current organisation',
     labelsGroupId
   );
-  const hasError = boolean('Has error?', false, generalGroupID);
-  const isDisabled = boolean('Is disabled?', false, generalGroupID);
+
   return (
     <form noValidate>
       <FormField>

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import Checkbox from 'Checkbox';
+import FormField from 'FormField';
+import FormFieldError from 'FormFieldError';
+import Label from 'Label';
+
+const CheckboxExample = () => {
+  const generalGroupID = 'General';
+  const labelsGroupId = 'Labels';
+
+  const errorMessage = text(
+    'Error message',
+    'Please confirm that your current organisation has been notified.',
+    generalGroupID
+  );
+  const label = text(
+    'Label',
+    'Current organisation has been notified',
+    labelsGroupId
+  );
+  const checkboxLabel = text(
+    'Checkbox label',
+    'I confirm that I have discussed this transfer with the research office at my current organisation',
+    labelsGroupId
+  );
+  const hasError = boolean('Has error?', false, generalGroupID);
+  const isDisabled = boolean('Is disabled?', false, generalGroupID);
+  return (
+    <form noValidate>
+      <FormField>
+        <Label
+          htmlFor="wasOrganisationNotified"
+          isDisabled={isDisabled}
+          text={label}
+        />
+        <Checkbox
+          describedBy={hasError && 'wasOrganisationNotifiedErrors'}
+          id="wasOrganisationNotified"
+          isDisabled={isDisabled}
+          isInvalid={hasError}
+          isRequired
+          label={checkboxLabel}
+          name="wasOrganisationNotified"
+        />
+        {hasError && (
+          <FormFieldError
+            errors={errorMessage}
+            id="wasOrganisationNotifiedErrors"
+          />
+        )}
+      </FormField>
+    </form>
+  );
+};
+
+const stories = storiesOf('Components/Checkbox', module);
+
+stories.add('Checkbox', CheckboxExample);

--- a/src/components/Checkbox/_checkbox.scss
+++ b/src/components/Checkbox/_checkbox.scss
@@ -65,6 +65,9 @@
   // Focused checkbox
   .cc-checkbox__input:not(:disabled):focus ~ &:before {
     box-shadow: 0 0 0 2px var(--colour-blue-30);
+
+    /* Box shadows don't show up in high contrast mode, we're adding a transparent outline (which does show up). */
+    outline: 2px dotted transparent;
   }
 
   /**

--- a/src/components/Checkbox/_checkbox.scss
+++ b/src/components/Checkbox/_checkbox.scss
@@ -51,7 +51,7 @@
   // Checked checkbox
   .cc-checkbox__input:checked ~ &:before {
     background-color: var(--colour-blue-60);
-    border: 0;
+    border-color: transparent;
   }
 
   // Hovered checkbox
@@ -88,6 +88,7 @@
   .cc-checkbox__input:disabled ~ &:before {
     background-color: var(--colour-grey-05);
     border: 1px solid var(--colour-grey-20);
+    cursor: default;
   }
 
   .cc-checkbox__input:disabled ~ & {

--- a/src/components/Checkbox/_checkbox.scss
+++ b/src/components/Checkbox/_checkbox.scss
@@ -12,7 +12,7 @@
 
 // Hide the <input /> element
 .cc-checkbox__input {
-  @include visually-hidden-input($top: 0.37rem);
+  @include visually-hidden-input;
 }
 
 .cc-checkbox {
@@ -35,7 +35,7 @@
     height: var(--checkbox-radio-size);
     left: 0;
     position: absolute;
-    top: 0.37rem;
+    top: var(--space-xs);
     width: var(--checkbox-radio-size);
   }
 
@@ -101,7 +101,7 @@
   left: 0.227rem;
   pointer-events: none;
   position: absolute;
-  top: 0.34rem;
+  top: var(--space-xs);
   width: 0.56rem;
 
   .cc-checkbox__input:not(:checked) ~ & {

--- a/src/components/Checkbox/_checkbox.scss
+++ b/src/components/Checkbox/_checkbox.scss
@@ -88,11 +88,11 @@
   .cc-checkbox__input:disabled ~ &:before {
     background-color: var(--colour-grey-05);
     border: 1px solid var(--colour-grey-20);
-    cursor: default;
   }
 
   .cc-checkbox__input:disabled ~ & {
     color: var(--colour-grey-30);
+    cursor: default;
   }
 }
 

--- a/src/components/Label/_label.scss
+++ b/src/components/Label/_label.scss
@@ -9,6 +9,7 @@
 .cc-label {
   color: var(--colour-grey-80);
   display: block;
+  line-height: var(--body-line-height);
   margin-bottom: var(--space-xs);
 
   // don't show hover state on input when hovering on label

--- a/src/components/RadioInput/RadioInput.stories.tsx
+++ b/src/components/RadioInput/RadioInput.stories.tsx
@@ -10,6 +10,9 @@ const RadioInputExample = () => {
   const generalGroupID = 'General';
   const labelsGroupId = 'Labels';
 
+  const hasError = boolean('Has error?', false, generalGroupID);
+  const isDisabled = boolean('Is disabled?', false, generalGroupID);
+
   const errorMessage = text(
     'Error message',
     'Select yes if this is the person who took leave',
@@ -22,8 +25,7 @@ const RadioInputExample = () => {
   );
   const firstRadioLabel = text('First radio label', 'Yes', labelsGroupId);
   const secondRadioLabel = text('Second radio label', 'No', labelsGroupId);
-  const hasError = boolean('Has error?', false, generalGroupID);
-  const isDisabled = boolean('Is disabled?', false, generalGroupID);
+
   return (
     <form noValidate>
       <FormFieldset legend={radioGroupLegend}>

--- a/src/components/RadioInput/RadioInput.stories.tsx
+++ b/src/components/RadioInput/RadioInput.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import FormFieldset from 'FormFieldset';
+import FormFieldError from 'FormFieldError';
+import RadioInput from 'RadioInput';
+
+const RadioInputExample = () => {
+  const generalGroupID = 'General';
+  const labelsGroupId = 'Labels';
+
+  const errorMessage = text(
+    'Error message',
+    'Select yes if this is the person who took leave',
+    generalGroupID
+  );
+  const radioGroupLegend = text(
+    'Group label',
+    'Is this the person who took leave?',
+    labelsGroupId
+  );
+  const firstRadioLabel = text('First radio label', 'Yes', labelsGroupId);
+  const secondRadioLabel = text('Second radio label', 'No', labelsGroupId);
+  const hasError = boolean('Has error?', false, generalGroupID);
+  const isDisabled = boolean('Is disabled?', false, generalGroupID);
+  return (
+    <form noValidate>
+      <FormFieldset legend={radioGroupLegend}>
+        <RadioInput
+          describedBy={hasError && 'isPersonWhoTookLeaveErrors'}
+          id="isPersonWhoTookLeaveYes"
+          isDisabled={isDisabled}
+          label={firstRadioLabel}
+          name="isPersonWhoTookLeave"
+          value="yes"
+        />
+        <RadioInput
+          describedBy={hasError && 'isPersonWhoTookLeaveErrors'}
+          id="isPersonWhoTookLeaveNo"
+          isDisabled={isDisabled}
+          label={secondRadioLabel}
+          name="isPersonWhoTookLeave"
+          value="no"
+        />
+        {hasError && (
+          <FormFieldError
+            errors={errorMessage}
+            id="isPersonWhoTookLeaveErrors"
+          />
+        )}
+      </FormFieldset>
+    </form>
+  );
+};
+
+const stories = storiesOf('Components/RadioInput', module);
+
+stories.add('RadioInput', RadioInputExample);

--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -54,14 +54,14 @@
     background-color: var(--colour-blue-60);
 
     /**
-     * The background is removed in Windows high-contrast mode, so we
+     * The background is removed in Windows High Contrast mode, so we
      * need to set it explicitly. `WindowText` is a system color
      * that should work with whatever high contrast mode the user has set.
      * This works on Windows 7+, IE 10+, Edge
      *
      *  @see {@link https://www.a11ywithlindsey.com/blog/create-custom-keyboard-accessible-radio-buttons}
      */
-    @media screen and (-ms-high-contrast: active) {
+    @media (-ms-high-contrast: active), (forced-colors: active) {
       background-color: WindowText;
     }
   }
@@ -83,7 +83,7 @@
   .cc-radio-input__input-element:not(:disabled):focus ~ &:before {
     box-shadow: 0 0 0 3px var(--colour-blue-30);
 
-    /* Since box shadows don't show up in high contrast mode, we're adding a transparent outline (which does show up). */
+    /* Box shadows don't show up in high contrast mode, we're adding a transparent outline (which does show up). */
     outline: 2px dotted transparent;
   }
 

--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -8,7 +8,7 @@
 
 // Hide the <input /> element
 .cc-radio-input__input-element {
-  @include visually-hidden-input($top: 0.3125rem);
+  @include visually-hidden-input;
 }
 
 .cc-radio-input {
@@ -82,6 +82,9 @@
   // Focused radio
   .cc-radio-input__input-element:not(:disabled):focus ~ &:before {
     box-shadow: 0 0 0 3px var(--colour-blue-30);
+
+    /* Since box shadows don't show up in high contrast mode, we're adding a transparent outline (which does show up). */
+    outline: 2px dotted transparent;
   }
 
   /**

--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -57,11 +57,10 @@
      * The background is removed in Windows High Contrast mode, so we
      * need to set it explicitly. `WindowText` is a system color
      * that should work with whatever high contrast mode the user has set.
-     * This works on Windows 7+, IE 10+, Edge
      *
-     *  @see {@link https://www.a11ywithlindsey.com/blog/create-custom-keyboard-accessible-radio-buttons}
+     *  @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors}
      */
-    @media (-ms-high-contrast: active), (forced-colors: active) {
+    @media (forced-colors: active) {
       background-color: WindowText;
     }
   }

--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -47,11 +47,23 @@
   // Checked Radio
   .cc-radio-input__input-element:checked ~ &:after,
   .cc-radio-input__input-element:checked ~ &:before {
-    border: 0;
+    border-color: transparent;
   }
 
   .cc-radio-input__input-element:checked ~ &:before {
     background-color: var(--colour-blue-60);
+
+    /**
+     * The background is removed in Windows high-contrast mode, so we
+     * need to set it explicitly. `WindowText` is a system color
+     * that should work with whatever high contrast mode the user has set.
+     * This works on Windows 7+, IE 10+, Edge
+     *
+     *  @see {@link https://www.a11ywithlindsey.com/blog/create-custom-keyboard-accessible-radio-buttons}
+     */
+    @media screen and (-ms-high-contrast: active) {
+      background-color: WindowText;
+    }
   }
 
   .cc-radio-input__input-element:checked ~ &:after {
@@ -92,5 +104,6 @@
 
   .cc-radio-input__input-element:disabled ~ & {
     color: var(--colour-grey-30);
+    cursor: default;
   }
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9052

### Context

Accessibility report:

The appearance of the radio buttons was not clear to low vision users that invert colours to view the page content. Ensure that the selected state of the radio button is clearly indicated to all users. Accessible customised radio buttons can be found on the GOV.UK Design System.

### This PR

- adds Checkbox and RadioInput stories
- adds `cursor: default` to disabled checkbox/radio
- fixes radio buttons in Windows High Contrast mode

### Test

- go to https://qa-9052-windows-radio.wellcome-dotorg-frontend.org/radio

If you have a Windows computer:

- turn high contrast on from the keyboard, press left Alt + left Shift + Print Screen
- test it in Edge, Chrome and Firefox

Or

- use VirtualMachine to test it: https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/
- select the Start button, and then select Settings > Ease of Access > High contrast
- test it in Edge, Chrome and Firefox

_VirtualMachine Example_

Top: old styles (yes button is selected and it is not visible)
Bottom: new styles (with focused outline)

![Screenshot 2021-10-27 at 16 48 54](https://user-images.githubusercontent.com/10700103/139102585-aa61e052-427c-4466-af2c-350d59c9bd50.png)

_Updated checkbox styles_

top - checkbox selected - current styles
bottom - checkbox selected - updated styles

![Screenshot 2021-10-28 at 11 33 42](https://user-images.githubusercontent.com/10700103/139240270-6e78ae29-2fbe-4cd7-81e5-49073d92c212.png)
