### PR TITLE
9123 bug: fixes incorrect link styles on the fact cards

### DIFF
--- a/src/components/CTALink/_cta-link.scss
+++ b/src/components/CTALink/_cta-link.scss
@@ -10,15 +10,10 @@
   @extend %anchor-inherit;
   @include animated-link($child-selector: '.btn__text');
 
-  display: block;
+  display: inline-block;
   line-height: var(--body-line-height);
   margin-right: calc(6 * var(--space-unit));
   position: relative;
-
-  @include mq(xs) {
-    align-items: center;
-    display: inline-flex;
-  }
 
   @include hocus {
     .btn__icon {


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9123

### Context

Two lines of link text on the fact component had one underline.

<img src="https://user-images.githubusercontent.com/10700103/139046378-a66e2db4-5ded-49d5-9a4c-487aaef8e6e2.png" />

### This PR

- fixes the underline styles

### Test

- git fetch this branch and git checkout
- `npm run storybook`
- find `FactCard` component
- choose `MultipleFactCard` (make sure you have three card in one row)
- replace `Optional text link` with `Read our strategy on diversity and inclusion`
- result:
<img width="480" alt="Screenshot 2021-10-28 at 12 37 00" src="https://user-images.githubusercontent.com/10700103/139248278-655a626c-d0bd-428c-a672-6aef781a1353.png">

