### PR TITLE
9135 task: changes InfoBox title to p

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -7,6 +7,7 @@ type TextProps = {
   children: string;
   className?: string;
   title?: string;
+  titleAs?: 'h3' | 'p';
   variant?: 'text' | 'text-snippet';
 };
 
@@ -14,15 +15,19 @@ export const Text = ({
   children,
   className,
   title,
+  titleAs = 'h3',
   variant = 'text'
 }: TextProps) => {
+  const TitleElement = variant === 'text-snippet' ? 'p' : titleAs;
   const classNames = cx(`cc-${variant}`, {
     [className]: className
   });
 
   return (
     <div className={classNames}>
-      {title && <h3 className={`cc-${variant}__title`}>{title}</h3>}
+      {title && (
+        <TitleElement className={`cc-${variant}__title`}>{title}</TitleElement>
+      )}
       <RichText variant={variant}>{children}</RichText>
     </div>
   );

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -7,7 +7,6 @@ type TextProps = {
   children: string;
   className?: string;
   title?: string;
-  titleAs?: 'h3' | 'p';
   variant?: 'text' | 'text-snippet';
 };
 
@@ -15,19 +14,15 @@ export const Text = ({
   children,
   className,
   title,
-  titleAs = 'h3',
   variant = 'text'
 }: TextProps) => {
-  const TitleElement = variant === 'text-snippet' ? 'p' : titleAs;
   const classNames = cx(`cc-${variant}`, {
     [className]: className
   });
 
   return (
     <div className={classNames}>
-      {title && (
-        <TitleElement className={`cc-${variant}__title`}>{title}</TitleElement>
-      )}
+      {title && <p className={`cc-${variant}__title`}>{title}</p>}
       <RichText variant={variant}>{children}</RichText>
     </div>
   );


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9135

### Context

Accessibility audit:

Where info boxes are near the top of the page, this gives an illogical heading structure, as it jumps directly from H1 page title to H3 info box title. Info box titles should not be labelled as headers.

### This PR

- if `Text` variant is `text_snippet` updates the title from `h3` to `p`
