### PR TITLE
9052 task: adds support for inverted colours in IE11

### DIFF
--- a/src/components/RadioInput/_radio-input.scss
+++ b/src/components/RadioInput/_radio-input.scss
@@ -60,7 +60,7 @@
      *
      *  @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors}
      */
-    @media (forced-colors: active) {
+    @media (-ms-high-contrast: active), (forced-colors: active) {
       background-color: WindowText;
     }
   }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9052

### Context

I checked the accessibility audit, the inverted colours were tested in IE11. 

<img width="877" alt="Screenshot 2021-11-04 at 12 29 46" src="https://user-images.githubusercontent.com/10700103/140314816-48201214-eef7-47cd-b8df-105f4d0eca03.png">

### This PR

- adds `(-ms-high-contrast: active)` to show a radio's background-color in IE11 
