### PR TITLE
9183 task: allows Label to accept markup

### DIFF
--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import cx from 'classnames';
 
 type LabelProps = {
+  children?: React.ReactNode;
   className?: string;
   htmlFor: string;
   isDisabled?: boolean;
-  text: string;
+  text?: string;
 };
 
 export const FormLabel = ({
+  children,
   className,
   htmlFor,
   isDisabled,
@@ -21,7 +23,7 @@ export const FormLabel = ({
 
   return (
     <label className={classNames} htmlFor={htmlFor}>
-      {text}
+      {children || text}
     </label>
   );
 };

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,15 +2,13 @@ import React from 'react';
 import cx from 'classnames';
 
 type LabelProps = {
-  children?: React.ReactNode;
   className?: string;
   htmlFor: string;
   isDisabled?: boolean;
-  text?: string;
+  text: string;
 };
 
 export const FormLabel = ({
-  children,
   className,
   htmlFor,
   isDisabled,
@@ -22,9 +20,12 @@ export const FormLabel = ({
   });
 
   return (
-    <label className={classNames} htmlFor={htmlFor}>
-      {children || text}
-    </label>
+    // eslint-disable-next-line jsx-a11y/label-has-associated-control
+    <label
+      dangerouslySetInnerHTML={{ __html: text }}
+      className={classNames}
+      htmlFor={htmlFor}
+    />
   );
 };
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9183

### Context

Allow the `Label` component to accept the markup. We need this for a label with an asterix to be accessible for the screen reader users.

Usage
```html
<Label>
   {text}
   <span aria-hidden="true">*</span>
</Label>

or

<Label text={label} />
```

![Screenshot 2021-11-11 at 15 14 24](https://user-images.githubusercontent.com/10700103/141323827-0132278a-4809-48f9-9104-22c36fab38a9.png)


### This PR
- allows the Label component to accept markup


