### PR TITLE
9225 bug: fixes date showing on a standard page type

### DIFF
--- a/src/components/PageHeaderCompact/PageHeaderCompact.tsx
+++ b/src/components/PageHeaderCompact/PageHeaderCompact.tsx
@@ -19,7 +19,7 @@ type AuthorPropsExtend = AuthorProps & {
 
 type PageHeaderCompactProps = {
   authors: AuthorPropsExtend[];
-  date: string;
+  date?: string;
   imageAlt?: string;
   imageCaption?: string;
   imageCredit?: string;
@@ -84,34 +84,38 @@ export const PageHeaderCompact = ({
         )}
       </figure>
     )}
-    <div className="cc-page-header-compact__aside cc-page-header-compact__section cc-page-header-compact__section--sidebar">
-      {authors && (
-        <div className="cc-page-header-compact__authors">
-          {authors.map(author => (
-            <Author
-              imageSrc={author.imageSrc}
-              imageSrcSet={author.imageSrcSet}
-              jobTitle={author.jobTitle}
-              links={author.links}
-              key={`author-${author.id}`}
-              name={`${author.name}`}
-              organisation={author.organisation}
-            />
-          ))}
-        </div>
-      )}
-      {topics && (
-        <div className="cc-page-header-compact__topics">
-          <TagList tags={topics} />
-        </div>
-      )}
-    </div>
-    <div className="cc-page-header-compact__tray cc-page-header-compact__section cc-page-header-compact__section--main">
-      <time dateTime={date}>
-        <FormattedDate dateString={date} />
-      </time>
-      <SocialShare url={socialUrl} body={standfirst} title={title} />
-    </div>
+    {(authors || !!topics?.length) && (
+      <div className="cc-page-header-compact__aside cc-page-header-compact__section cc-page-header-compact__section--sidebar">
+        {authors && (
+          <div className="cc-page-header-compact__authors">
+            {authors.map(author => (
+              <Author
+                imageSrc={author.imageSrc}
+                imageSrcSet={author.imageSrcSet}
+                jobTitle={author.jobTitle}
+                links={author.links}
+                key={`author-${author.id}`}
+                name={`${author.name}`}
+                organisation={author.organisation}
+              />
+            ))}
+          </div>
+        )}
+        {!!topics?.length && (
+          <div className="cc-page-header-compact__topics">
+            <TagList tags={topics} />
+          </div>
+        )}
+      </div>
+    )}
+    {date && (
+      <div className="cc-page-header-compact__tray cc-page-header-compact__section cc-page-header-compact__section--main">
+        <time dateTime={date}>
+          <FormattedDate dateString={date} />
+        </time>
+        <SocialShare url={socialUrl} body={standfirst} title={title} />
+      </div>
+    )}
   </header>
 );
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9225

### Context

1 January 1970 was showing as an article published date on a standard page.
We were passing `null` as a date and in the [FormattedDate component](https://github.com/wellcometrust/corporate-components/blob/develop/src/components/FormattedDate/FormattedDate.tsx#L9) we were creating a dateObject using `new Date`
```js
 const dateObject = new Date(dateString);
```
if dateString is null we are getting `1 January 1970`

### This PR

- adds check to prevent empty div from showing on pages without authors or topics,
- adds check in `PageHeaderCompact` to prevent incorrect date from showing