### PR TITLE
9236 chore: manually updated package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wellcometrust/corporate-components",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wellcometrust/corporate-components",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wellcometrust/corporate-components",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Component library for main Wellcome Trust corporate site",
   "main": "dist/index.js",
   "style": "dist/styles.css",


### PR DESCRIPTION
Relates to wellcometrust/corporate#9236

Abortive attempt to introduce process to handle creation of github release and npm package simultaneously has required the tag for v0.19.1 to be added manually.