### PR TITLE
9266 task: FormSelect accepts two types of options

### DIFF
--- a/src/components/FormSelect/FormSelect.tsx
+++ b/src/components/FormSelect/FormSelect.tsx
@@ -1,13 +1,18 @@
 import React, { forwardRef } from 'react';
 import cx from 'classnames';
 
+type FormSelectOptionProps = {
+  label: string;
+  value?: string;
+};
+
 type FormSelectProps = {
   className?: string;
   defaultText?: string;
   id: string;
   isRequired?: boolean;
   name: string;
-  options: string[];
+  options: (string | FormSelectOptionProps)[];
 };
 
 export const FormSelect = forwardRef(
@@ -38,9 +43,19 @@ export const FormSelect = forwardRef(
         <option disabled value="">
           {defaultText}
         </option>
-        {options.map(option => (
-          <option key={`option-${option}`}>{option}</option>
-        ))}
+        {options.map(option => {
+          if (typeof option === 'object') {
+            return (
+              <option
+                key={`option-${option.label}`}
+                value={option.value || option.label}
+              >
+                {option.label}
+              </option>
+            );
+          }
+          return <option key={`option-${option}`}>{option}</option>;
+        })}
       </select>
     );
   }

--- a/src/components/FormSelect/FormSelect.tsx
+++ b/src/components/FormSelect/FormSelect.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 
 type FormSelectOptionProps = {
   label: string;
-  value?: string;
+  value: string;
 };
 
 type FormSelectProps = {
@@ -46,10 +46,7 @@ export const FormSelect = forwardRef(
         {options.map(option => {
           if (typeof option === 'object') {
             return (
-              <option
-                key={`option-${option.label}`}
-                value={option.value || option.label}
-              >
+              <option key={`option-${option.label}`} value={option.value}>
                 {option.label}
               </option>
             );


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9266

### This PR

- allows `FormSelect` to accept two types of options: an array of strings or an array of object (with `label` and `value`)

`FormSelect` with array of strings is used on the forms and with an array of objects on newsletter signup.