### PR TITLE
9281 task: Removed extraneous external link processing for rich text

### DIFF
--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -13,23 +13,6 @@ type RichTextProps = {
   variant?: 'text' | 'text-snippet';
 };
 
-/**
- * Find all anchor elements with target="_blank"
- *
- * Regex groups
- * (?!.*class="non")               Negative lookahead to filter out any matches which contain this class
- * (?!.*href="https?:\/\/(www\.)?wellcome.(org|ac\.uk).*".*)
- *                                 Negative lookahead to filter out absolute links to the Wellcome site
- *     (?:www\.)?                  Non-capturing group matches the optional www prefix
- *     (?:org|ac\.uk)              Non-capturing group matches the possible domain endings
- * (?!.*href="mailto:)             Negative lookahead to filter out email links
- * (<a[^>]*target="_blank"[^>]*>)  Opening anchor tag which has a target="_blank" attribute
- * ([^<]+)                         The anchor content (any character which is not a left angle bracket)
- * (<\/a>)                         Closing anchor tag
- */
-// TODO: replace `non` with class name to be ignored
-const regexAnchorExternal = /(?!.*class="non")(?!.*href="https?:\/\/(?:www\.)?wellcome.(?:org|ac\.uk).*".*)(?!.*href="mailto:)(<a[^>]*target="_blank"[^>]*>)([^<]+)(<\/a>)/g;
-
 const regexTableElements = /<table(.*?)>(.|\n)(.*?)(.|\n)*<\/table>/g;
 
 /**
@@ -46,23 +29,6 @@ const formatHTMLString = (children: string) => {
 
     return (
       children
-        /**
-         * Add markup to all anchor elements which open in a new window
-         * to indicate an external link
-         */
-        .replaceAll(regexAnchorExternal, (match, p1, p2, p3) =>
-          // replace existing anchor string with embellished version containing assistive text
-          // p[n] refers to each group within the match - groups are defined within parentheses
-          // p1 and p2 are contained in the 2nd negative lookup
-          // so we start with p3 as the first actual string
-          p1
-            ? `${p1.substring(
-                0,
-                p1.length - 1
-              )} rel="nofollow noreferrer" class="u-link-new-window">${p2}${externalMarker}${p3}`
-            : match
-        )
-
         /**
          * Add markup to wrap <table> elements with a <div> to prevent overflow-x
          * on the rich-text element, constraining the overflow-x to only the

--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import cx from 'classnames';
-
-import { ExternalLinkMarker } from 'Link';
 
 import { sanitizeHtml } from 'utils/sanitize-html';
 
@@ -24,9 +21,6 @@ const regexTableElements = /<table(.*?)>(.|\n)(.*?)(.|\n)*<\/table>/g;
  */
 const formatHTMLString = (children: string) => {
   try {
-    // renderToStaticMarkup used to preserve svg attributes in JSX format for re-rendering
-    const externalMarker = renderToStaticMarkup(<ExternalLinkMarker />);
-
     return (
       children
         /**

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -42,8 +42,4 @@ describe('<Text />', () => {
     expect(outputRender.find('[href]')).toHaveLength(7);
     expect(outputRender.find('[href]')).not.toContain('javascript');
   });
-
-  it('ignores email links and absolute links to wellcome.org or wellcome.ac.uk when adding external link icons', () => {
-    expect(outputRender.find('.u-link-new-window')).toHaveLength(2);
-  });
 });


### PR DESCRIPTION
Relates to wellcometrust/corporate#9281 and wellcometrust/corporate#7949

Find and replace functionality for processing external links is no longer needed on frontend.