### PR TITLE
8905 bug: Prevent gaps caused by long image captions

### DIFF
--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -31,9 +31,9 @@ const Media = ({
       <div className="cc-media__element">{children}</div>
       <MediaCaption
         caption={caption}
-        captionVariant={captionVariant}
         className={cx({
-          'cc-media--wide__caption': captionVariant === 'right'
+          'cc-media--caption-below-image': captionVariant === 'below',
+          'cc-media--caption-beside-image': captionVariant === 'right'
         })}
         credit={credit}
         licence={licence}

--- a/src/components/Media/MediaCaption.tsx
+++ b/src/components/Media/MediaCaption.tsx
@@ -5,7 +5,6 @@ import { sanitizeHtml } from 'utils/sanitize-html';
 
 type MediaCaptionProps = {
   caption?: string;
-  captionVariant?: 'below' | 'right';
   className?: string;
   credit?: string;
   licence?: string;
@@ -14,41 +13,41 @@ type MediaCaptionProps = {
 
 const MediaCaption = ({
   caption,
-  captionVariant = 'right',
   className,
   credit,
   licence,
   shouldHideCaption
 }: MediaCaptionProps) => {
   const classNames = cx('cc-media__caption', {
-    'cc-media__caption--below-image': captionVariant === 'below',
     [`${className}`]: className
   });
 
   return (caption && !shouldHideCaption) || credit ? (
     <figcaption className={classNames}>
-      {caption && !shouldHideCaption && (
-        <div
-          className="cc-media__caption-detail"
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(caption) }}
-        />
-      )}
-      {credit && (
-        <div
-          className="cc-media__credit"
-          dangerouslySetInnerHTML={{
-            __html: `Credit: ${sanitizeHtml(credit)}`
-          }}
-        />
-      )}
-      {licence && (
-        <div
-          className="cc-media__licence"
-          dangerouslySetInnerHTML={{
-            __html: `Licence: ${sanitizeHtml(licence)}`
-          }}
-        />
-      )}
+      <div className="cc-media__caption-content">
+        {caption && !shouldHideCaption && (
+          <div
+            className="cc-media__caption-detail"
+            dangerouslySetInnerHTML={{ __html: sanitizeHtml(caption) }}
+          />
+        )}
+        {credit && (
+          <div
+            className="cc-media__credit"
+            dangerouslySetInnerHTML={{
+              __html: `Credit: ${sanitizeHtml(credit)}`
+            }}
+          />
+        )}
+        {licence && (
+          <div
+            className="cc-media__licence"
+            dangerouslySetInnerHTML={{
+              __html: `Licence: ${sanitizeHtml(licence)}`
+            }}
+          />
+        )}
+      </div>
     </figcaption>
   ) : null;
 };

--- a/src/components/Media/_media.scss
+++ b/src/components/Media/_media.scss
@@ -29,21 +29,14 @@
 
 .cc-media__caption {
   align-self: start;
-  // D7 override
-  border: 0;
-  border-left: 1px solid var(--color-grey-70);
-  color: var(--color-grey-70);
-  font-size: var(--body-xxs);
-  line-height: var(--body-line-height);
   margin-top: calc(2 * var(--space-unit));
-  padding: calc(0.25 * var(--space-unit)) 0 calc(0.25 * var(--space-unit)) calc(2 * var(--space-unit));
 
   a {
     @include animated-link;
   }
 }
 
-.cc-media__caption--below-image {
+.cc-media--caption--below-image {
   @include grid-column(1, 7);
 
   @include mq(sm) {
@@ -55,7 +48,7 @@
   }
 }
 
-.cc-media--wide__caption {
+.cc-media--caption-beside-image {
   @include grid-column(1, 7);
 
   @include mq(sm) {
@@ -65,6 +58,24 @@
   @include mq(md) {
     @include grid-column(10, 13);
     margin-top: 0;
+    position: relative;
+  }
+}
+
+.cc-media__caption-content {
+  border-left: 1px solid var(--color-grey-70);
+  color: var(--color-grey-70);
+  font-size: var(--body-xxs);
+  line-height: var(--body-line-height);
+  padding: calc(0.25 * var(--space-unit)) 0 calc(0.25 * var(--space-unit)) calc(2 * var(--space-unit));
+}
+
+.cc-media--caption-beside-image .cc-media__caption-content {
+  @include mq(md) {
+    left: 0;
+    right: 0;
+    position: absolute;
+    top: 0;
   }
 }
 

--- a/src/components/Media/_media.scss
+++ b/src/components/Media/_media.scss
@@ -36,7 +36,7 @@
   }
 }
 
-.cc-media--caption--below-image {
+.cc-media--caption-below-image {
   @include grid-column(1, 7);
 
   @include mq(sm) {


### PR DESCRIPTION
Relates to wellcometrust/corporate#8905

Allows right aligned image (and video) caption to overlap the content row beneath to prevent excess gapping due to CSS grid (screen width of 1024px and above). The caveat to this work is that there must be sufficient content to prevent overlap of other content which occupies the right hand column. The content team have been made aware of this.

Current layout showing CSS grid:
![Screenshot 2021-12-09 at 15 15 20](https://user-images.githubusercontent.com/49439125/145423494-0d080d32-d178-4e47-a5e8-34c557990afa.png)


Modified layout:
![Screenshot 2021-12-09 at 15 14 30](https://user-images.githubusercontent.com/49439125/145423475-05830989-c084-4c15-836d-2cdb3de91c0a.png)

