### PR TITLE
8904 bug: fixes gap in the header when the sidebar longer than content

### DIFF
--- a/src/components/PageHeaderCompact/_page-header-compact.scss
+++ b/src/components/PageHeaderCompact/_page-header-compact.scss
@@ -18,6 +18,7 @@
     display: grid;
     // stylelint-disable value-no-vendor-prefix
     display: -ms-grid;
+    position: relative;
   }
 
   @include mq(xl) {
@@ -72,6 +73,7 @@
     margin-top: calc(var(--body-sm) +
     (2 * var(--space-unit)) +
     (var(--body-line-height) * var(--body-sm) * 0.5));
+    position: absolute;
   }
 }
 


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8904

### Context

The two authors in the header increase the header size and the same happens with the image caption when the screen width narrows (1024px up to about 1340px).

![Screenshot 2022-01-05 at 16 13 50](https://user-images.githubusercontent.com/10700103/148250717-c0c90d71-7669-48c1-a557-6e146d9c3ad4.png)

###  This PR

- fixes this issue

![Screenshot 2022-01-05 at 16 15 23](https://user-images.githubusercontent.com/10700103/148250953-993ffaf3-3c04-4e8a-a134-cb5bb9b6a93a.png)


