### PR TITLE
9301 bug: fixes compact header image caption

### DIFF
--- a/src/components/PageHeaderCompact/PageHeaderCompact.tsx
+++ b/src/components/PageHeaderCompact/PageHeaderCompact.tsx
@@ -67,19 +67,23 @@ export const PageHeaderCompact = ({
         />
         {(imageCaption || imageCredit || imageLicence) && (
           <figcaption className="cc-media__caption">
-            {imageCaption && (
-              <RichText className="cc-media__caption-detail">
-                {imageCaption}
-              </RichText>
-            )}
-            {imageCredit && (
-              <RichText className="cc-media__credit">
-                {`Credit: ${imageCredit}`}
-              </RichText>
-            )}
-            {imageLicence && (
-              <RichText className="cc-media__license">{imageLicence}</RichText>
-            )}
+            <div className="cc-media__caption-content">
+              {imageCaption && (
+                <RichText className="cc-media__caption-detail">
+                  {imageCaption}
+                </RichText>
+              )}
+              {imageCredit && (
+                <RichText className="cc-media__credit">
+                  {`Credit: ${imageCredit}`}
+                </RichText>
+              )}
+              {imageLicence && (
+                <RichText className="cc-media__license">
+                  {imageLicence}
+                </RichText>
+              )}
+            </div>
           </figcaption>
         )}
       </figure>


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9301

### Context

Image caption had an incorrect styles.

![Screenshot 2022-01-05 at 16 40 10](https://user-images.githubusercontent.com/10700103/148254863-20e7b78f-c843-48e0-b5a1-86058b4b61f7.png)


Link: https://develop.wellcome-dotorg-frontend.org/news/public-trust-scientists-rose-during-covid-19-pandemic 

### This PR

- adds a wrapping div with `cc-media__caption-content` class

![Screenshot 2022-01-05 at 16 40 36](https://user-images.githubusercontent.com/10700103/148254933-25dfb16a-6750-4c69-9e45-8173e54c99f7.png)
