### PR TITLE
9327 task(style): updates SidebarSearch

### DIFF
--- a/src/components/SidebarSearch/SidebarSearch.tsx
+++ b/src/components/SidebarSearch/SidebarSearch.tsx
@@ -38,27 +38,29 @@ export const SidebarSearch = ({
         htmlFor={`search-${id}`}
         text={label}
       />
-      <input
-        className="cc-sidebar-search__input"
-        name={`search-${id}`}
-        onChange={onChange}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        placeholder={placeholder}
-        value={value}
-        id={`search-${id}`}
-      />
-      <Button
-        className="cc-sidebar-search__btn"
-        icon="search"
-        iconClassName="u-mr-0 u-ml-0"
-        iconPlacementSwitch
-        onClick={onClick}
-        textClassName="u-visually-hidden"
-        variant="unstyled"
-      >
-        Search
-      </Button>
+      <div className="cc-sidebar-search__control">
+        <input
+          className="cc-sidebar-search__input"
+          name={`search-${id}`}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
+          placeholder={placeholder}
+          value={value}
+          id={`search-${id}`}
+        />
+        <Button
+          className="cc-sidebar-search__btn"
+          icon="search"
+          iconClassName="u-mr-0 u-ml-0"
+          iconPlacementSwitch
+          onClick={onClick}
+          textClassName="u-visually-hidden"
+          variant="unstyled"
+        >
+          Search
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/SidebarSearch/_sidebar-search.scss
+++ b/src/components/SidebarSearch/_sidebar-search.scss
@@ -7,7 +7,9 @@
 // ----------------------------------
 
 .cc-sidebar-search {
+  border-top: 1px solid var(--color-grey-10);
   display: block;
+  padding-top: var(--space-md);
   position: relative;
 }
 
@@ -17,6 +19,10 @@
   .cc-sidebar-filter & {
     font-size: var(--body-sm);
   }
+}
+
+.cc-sidebar-search__control {
+  position: relative;
 }
 
 .cc-sidebar-search__input {
@@ -33,5 +39,5 @@
   padding-top: calc(2.375 * var(--space-unit));
   position: absolute;
   right: 0;
-  top: calc(3.5 * var(--space-unit));
+  top: 0;
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9327

### This PR

- adds missing border for the `SidebarSearch` component used on the listing pages

|  BEFORE | AFTER  |
|---|---|
| <img width="370" alt="Screenshot 2022-01-06 at 16 42 37" src="https://user-images.githubusercontent.com/10700103/148419705-375f1f03-c143-4363-aa3d-335a48b6bd1a.png"> | <img width="272" alt="Screenshot 2022-01-06 at 16 53 27" src="https://user-images.githubusercontent.com/10700103/148419788-cc0f8a05-1e17-4e53-b6ec-60c43e8ae279.png"> |  
