### PR TITLE
9369 task: illogical timeline headings

### DIFF
--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -63,7 +63,7 @@ export const Timeline = ({
    * In order to maintain a correct headers order we should update an timeline's item
    * heading if a timeline title not present.
    */
-  const ItemTitleElement = title ? 'h4' : 'h3'; // maintain correct header order
+  const ItemTitleElement = title ? 'h4' : 'h3';
   const classNames = cx('cc-timeline', {
     [className]: className
   });

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -59,6 +59,11 @@ export const Timeline = ({
   milestones,
   title
 }: TimelineProps) => {
+  /**
+   * In order to maintain a correct headers order we should update an timeline's item
+   * heading if a timeline title not present.
+   */
+  const ItemTitleElement = title ? 'h4' : 'h3'; // maintain correct header order
   const classNames = cx('cc-timeline', {
     [className]: className
   });
@@ -139,7 +144,9 @@ export const Timeline = ({
                 </a>
               )}
               <div className="cc-timeline__item-details">
-                <h4 className="cc-timeline__item-title">{item.title}</h4>
+                <ItemTitleElement className="cc-timeline__item-title">
+                  {item.title}
+                </ItemTitleElement>
                 {item.body && (
                   <RichText className="cc-timeline__item-body">
                     {item.body}


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/9369

### Context

When a timeline component doesn't have a title it created an illogical heading structure

![Screenshot 2022-01-17 at 15 34 28](https://user-images.githubusercontent.com/10700103/149798695-a17a50d1-587d-4463-9d02-2f52429b9303.png)


### This PR

- update timeline item header to update according to presence of timeline title

