### PR TITLE
8946 task: adds accessible phone text

### DIFF
--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Icon from 'Icon';
 import ImageElement from 'Image/ImageElement';
 import RichText from 'RichText';
+import VisuallyHidden from 'VisuallyHidden';
 
 type ContactImageSourceProps = {
   image_full_hi?: string;
@@ -45,6 +46,8 @@ export const Contact = ({
     'cc-contact--nested': isNested,
     [className]: className
   });
+
+  const accessiblePhoneText = name ? `Phone ${name} on` : 'Phone us on';
 
   return (
     <div className={classNames} itemScope itemType="http://schema.org/Person">
@@ -97,6 +100,7 @@ export const Contact = ({
         <p className="cc-contact__item">
           <Icon name="phone" className="cc-contact__link-icon" />
           <a href={`tel://${tel}`} className="cc-contact__link">
+            <VisuallyHidden>{accessiblePhoneText}</VisuallyHidden>
             {tel}
           </a>
         </p>


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/8946

We are using a Contact us component to add a phone number e.g. on the scheme pages. 

See [Wellcome Early-Career Awards page](https://wellcome.org/grant-funding/schemes/early-career-awards)

Accessible audit pointed that:
> Telephone link ambiguous for screen readers. You could amend the hypertext so that it is more descriptive for users browsing out of context, .i.e. 'Phone us on...'

As this component can be use to add a person contact details I added a logic based on a name.


### This PR

- adds accessible phone text